### PR TITLE
This just tweaks the version string to an underscore to allow bdist_rpm to work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from distutils.core import setup
 
 setup(
   name='whisper',
-  version='0.9.10-pre2',
+  version='0.9.10_pre2',
   url='https://launchpad.net/graphite',
   author='Chris Davis',
   author_email='chrismd@gmail.com',


### PR DESCRIPTION
This is a small change, but is required to generate RPMs with setup.py using bdist_rpm.
