### PR TITLE
Trivial fix for whisper-dump

### DIFF
--- a/bin/whisper-dump.py
+++ b/bin/whisper-dump.py
@@ -24,7 +24,7 @@ else:
 
 def mmap_file(filename):
   fd = os.open(filename, os.O_RDONLY)
-  map = mmap.mmap(fd, 0, prot=mmap.PROT_READ)
+  map = mmap.mmap(fd, os.fstat(fd).st_size, prot=mmap.PROT_READ)
   os.close(fd)
   return map
 


### PR DESCRIPTION
Running whisper-dump on RedHat 5 produces the following error:

Traceback (most recent call last):
  File "/usr/bin/whisper-dump.py", line 84, in ?
    map = mmap_file(path)
  File "/usr/bin/whisper-dump.py", line 19, in mmap_file
    map = mmap.mmap(fd, 0, prot=mmap.PROT_READ)
EnvironmentError: [Errno 22] Invalid argument

Which can be fixed by supplying an explicit size to the mmap call.
