### PR TITLE
whisper.merge: fromTime was not being set for each iteration of archive

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -809,8 +809,9 @@ def merge(path_from, path_to, step=1<<12):
 
   # Start from maxRetention of the oldest file, and skip forward at max 'step'
   # points at a time.
-  fromTime = int(time.time()) - headerFrom['maxRetention']
+  now = int( time.time() )
   for archive in archives:
+    fromTime = now - headerFrom['maxRetention']
     pointsRemaining = archive['points']
     while pointsRemaining:
       pointsToRead = step


### PR DESCRIPTION
Note: this is my first pull request.  If I made a newbie mistake, please say so nicely.

When working to merge whisper files, I hit a bug where the fromTime in whisper.merge() was into the future.  The problem I see is that fromTime was not getting reset on the second iteration of the archive.  Due to that, it was going into the future by the retention time I have set.  

In order to correct that, I made two changes:
1- Created a variable 'now' that is set to time.time(), so 'now' is the same value for all iterations of
     archive.

2- Set the variable fromTime at the top of the iteration for archive.  This makes it start at the correct 
     point, so it is not working into the future.

I have tested with multiple whisper files on my system, and it is working correctly.  Please review.
