### PR TITLE
Enforce xFilesFactor between 0 and 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ whisper-set-aggregation-method.py
 Change the aggregation method of an existing whisper file.
 
 ```
-Usage: whisper-set-aggregation-method.py path <average|sum|last|max|min>
+Usage: whisper-set-aggregation-method.py path <average|sum|last|max|min> [xFilesFactor]
 
 Options:
   -h, --help  show this help message and exit


### PR DESCRIPTION
It was bugging me that I could set illogical xFilesFactor values.  Now they raise ValueError.
New tests included.