### PR TITLE
Replace use of dict for duplicate removal

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -650,12 +650,13 @@ def __archive_update_many(fh,header,archive,points):
   step = archive['secondsPerPoint']
   alignedPoints = [ (timestamp - (timestamp % step), value)
                     for (timestamp,value) in points ]
-  alignedPoints = dict(alignedPoints).items() # Take the last val of duplicates
   #Create a packed string for each contiguous sequence of points
   packedStrings = []
   previousInterval = None
   currentString = ""
   for (interval,value) in alignedPoints:
+    if interval == previousInterval:
+      currentString[-pointSize] = struct.pack(pointFormat, interval, value)
     if (not previousInterval) or (interval == previousInterval + step):
       currentString += struct.pack(pointFormat,interval,value)
       previousInterval = interval


### PR DESCRIPTION
The use of dict introduced in ec98f92 can cause issues when large sets
of points are introduced. The order of data in the dict is unreliable
(in cPython anyways), and starts to mix things up when thousands of
points are introduced. While the stored data is correct, it can
cause extra seeks/writes. Its also super confusing when debugging.

This patch is similar to the implementation of a8e30fa, but adheres to
documented expectations.

It is also faster than the dict, at least for large sets of points. For
small sets, the difference is unmeasurable.
