### PR TITLE
Revert "Replace use of dict for duplicate removal"

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -650,13 +650,12 @@ def __archive_update_many(fh,header,archive,points):
   step = archive['secondsPerPoint']
   alignedPoints = [ (timestamp - (timestamp % step), value)
                     for (timestamp,value) in points ]
+  alignedPoints = dict(alignedPoints).items() # Take the last val of duplicates
   #Create a packed string for each contiguous sequence of points
   packedStrings = []
   previousInterval = None
   currentString = ""
   for (interval,value) in alignedPoints:
-    if interval == previousInterval:
-      currentString[-pointSize] = struct.pack(pointFormat, interval, value)
     if (not previousInterval) or (interval == previousInterval + step):
       currentString += struct.pack(pointFormat,interval,value)
       previousInterval = interval


### PR DESCRIPTION
The changes introduced by 48bcbbfc92546618d09843f38804769341eaaa61 cause a `'str' object does not support
item assignment` exception; this patch restores the previous behavior
until a more permanent fix to the issue 48bcbbfc92546618d09843f38804769341eaaa61 attempts to address is
made.
