### PR TITLE
added a check to ensure we have a path for the data files to be housed in when adding new metrics.  this can otherwise fail

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -381,6 +381,12 @@ aggregationMethod specifies the function to use when propogating data (see ``whi
     raise InvalidConfiguration("File %s already exists!" % path)
   fh = None
   try:
+
+    # ensure the path
+    _path_dir = os.path.split(path)[0]
+    if not os.path.exists( _path_dir ):
+        os.makedirs( _path_dir )
+
     fh = open(path,'wb')
     if LOCK:
       fcntl.flock( fh.fileno(), fcntl.LOCK_EX )


### PR DESCRIPTION
my metrics weren't showing up, and log files growing -- whipser was trying to put a `.wsp` file in a directory that didn't exist.

simple fix -- use `os.makedirs` to create the intermediate directories

others seem to have had this issue as well.  comments in https://github.com/graphite-project/carbon/issues/11 and a few other places.

the same 3 lines works in the 0.9.10 release as well  -- just outdented 2 spaces and put on line 327