### PR TITLE
Fix error in rrd2whisper

### DIFF
--- a/bin/rrd2whisper.py
+++ b/bin/rrd2whisper.py
@@ -75,9 +75,8 @@ else:
     rra_info['xff'] = rrd_info['rra[%d].xff' % i]
     rras.append(rra_info)
 
-datasources = []
 if 'ds' in rrd_info:
-  datasource_names = rrd_info['ds'].keys()
+  datasources = rrd_info['ds'].keys()
 else:
   ds_keys = [key for key in rrd_info if key.startswith('ds[')]
   datasources = list(set(key[3:].split(']')[0] for key in ds_keys))


### PR DESCRIPTION
I think there is an error in rrd2whisper.py where datasources can be empty in case rrd_info contains 'ds'.