### PR TITLE
Fix Whisper library improperly using current time to calculate archive

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -776,7 +776,7 @@ def file_fetch(fh, fromTime, untilTime, now = None):
   if untilTime > now:
     untilTime = now
 
-  diff = now - fromTime
+  diff = untilTime - fromTime
   for archive in header['archives']:
     if archive['retention'] >= diff:
       break


### PR DESCRIPTION
When looking for which archive to use from inside a Whisper file, the
Whisper library is improperly using the current time to find the
archive to be used. Instead the difference between untilTime and
fromTime should be used.

This issue can be reproduced by turning off caching and doing several
successive calls to the render API with a from time of -24hours. If
the system clock happens to advance the current time +1 second in the
middle of a call, the wrong archive will be used from inside the
Whisper file and different result will be returned.
