### PR TITLE
Adds new absmax aggregation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Options:
   --aggregationMethod=AGGREGATIONMETHOD
                         The consolidation function to fetch from on input and
                         aggregationMethod to set on output. One of: average,
-                        last, max, min, absmax
+                        last, max, min, absmax, absmin
 ```
 
 whisper-create.py
@@ -59,7 +59,7 @@ Options:
   --xFilesFactor=XFILESFACTOR
   --aggregationMethod=AGGREGATIONMETHOD
                         Function to use when aggregating values (average, sum,
-                        last, max, min, absmax)
+                        last, max, min, absmax, absmin)
   --overwrite
   --estimate            Don't create a whisper file, estimate storage requirements based on archive definitions
 ```
@@ -154,7 +154,7 @@ Options:
                         Change the xFilesFactor
   --aggregationMethod=AGGREGATIONMETHOD
                         Change the aggregation function (average, sum, last,
-                        max, min, absmax)
+                        max, min, absmax, absmin)
   --force               Perform a destructive change
   --newfile=NEWFILE     Create a new database file without removing the
                         existing one
@@ -169,7 +169,7 @@ whisper-set-aggregation-method.py
 Change the aggregation method of an existing whisper file.
 
 ```
-Usage: whisper-set-aggregation-method.py path <average|sum|last|max|min|absmax>
+Usage: whisper-set-aggregation-method.py path <average|sum|last|max|min|absmax|absmin>
 
 Options:
   -h, --help  show this help message and exit

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Options:
   --aggregationMethod=AGGREGATIONMETHOD
                         The consolidation function to fetch from on input and
                         aggregationMethod to set on output. One of: average,
-                        last, max, min, absmax, absmin
+                        last, max, min, avg_zero, absmax, absmin
 ```
 
 whisper-create.py
@@ -59,7 +59,7 @@ Options:
   --xFilesFactor=XFILESFACTOR
   --aggregationMethod=AGGREGATIONMETHOD
                         Function to use when aggregating values (average, sum,
-                        last, max, min, absmax, absmin)
+                        last, max, min, avg_zero, absmax, absmin)
   --overwrite
   --estimate            Don't create a whisper file, estimate storage requirements based on archive definitions
 ```
@@ -154,7 +154,7 @@ Options:
                         Change the xFilesFactor
   --aggregationMethod=AGGREGATIONMETHOD
                         Change the aggregation function (average, sum, last,
-                        max, min, absmax, absmin)
+                        max, min, avg_zero, absmax, absmin)
   --force               Perform a destructive change
   --newfile=NEWFILE     Create a new database file without removing the
                         existing one
@@ -169,7 +169,7 @@ whisper-set-aggregation-method.py
 Change the aggregation method of an existing whisper file.
 
 ```
-Usage: whisper-set-aggregation-method.py path <average|sum|last|max|min|absmax|absmin>
+Usage: whisper-set-aggregation-method.py path <average|sum|last|max|min|avg_zero|absmax|absmin>
 
 Options:
   -h, --help  show this help message and exit

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Options:
   --aggregationMethod=AGGREGATIONMETHOD
                         The consolidation function to fetch from on input and
                         aggregationMethod to set on output. One of: average,
-                        last, max, min
+                        last, max, min, absmax
 ```
 
 whisper-create.py
@@ -59,7 +59,7 @@ Options:
   --xFilesFactor=XFILESFACTOR
   --aggregationMethod=AGGREGATIONMETHOD
                         Function to use when aggregating values (average, sum,
-                        last, max, min)
+                        last, max, min, absmax)
   --overwrite
   --estimate            Don't create a whisper file, estimate storage requirements based on archive definitions
 ```
@@ -154,7 +154,7 @@ Options:
                         Change the xFilesFactor
   --aggregationMethod=AGGREGATIONMETHOD
                         Change the aggregation function (average, sum, last,
-                        max, min)
+                        max, min, absmax)
   --force               Perform a destructive change
   --newfile=NEWFILE     Create a new database file without removing the
                         existing one
@@ -169,7 +169,7 @@ whisper-set-aggregation-method.py
 Change the aggregation method of an existing whisper file.
 
 ```
-Usage: whisper-set-aggregation-method.py path <average|sum|last|max|min>
+Usage: whisper-set-aggregation-method.py path <average|sum|last|max|min|absmax>
 
 Options:
   -h, --help  show this help message and exit

--- a/bin/rrd2whisper.py
+++ b/bin/rrd2whisper.py
@@ -25,6 +25,8 @@ aggregationMethods = whisper.aggregationMethods
 aggregationMethods.remove('sum')
 # RRD doesn't have a 'absmax' type
 aggregationMethods.remove('absmax')
+# RRD doesn't have a 'absmin' type
+aggregationMethods.remove('absmin')
 
 option_parser = optparse.OptionParser(usage='''%prog rrd_path''')
 option_parser.add_option(

--- a/bin/rrd2whisper.py
+++ b/bin/rrd2whisper.py
@@ -23,6 +23,8 @@ aggregationMethods = whisper.aggregationMethods
 
 # RRD doesn't have a 'sum' or 'total' type
 aggregationMethods.remove('sum')
+# RRD doesn't have a 'absmax' type
+aggregationMethods.remove('absmax')
 
 option_parser = optparse.OptionParser(usage='''%prog rrd_path''')
 option_parser.add_option(

--- a/test_whisper.py
+++ b/test_whisper.py
@@ -188,9 +188,12 @@ class TestWhisper(WhisperTestBase):
         self.assertEqual(whisper.aggregate('average', [1, 2, 3, 4]), 2.5)
         avg_zero = [1, 2, 3, 4, None, None, None, None]
         non_null = [i for i in avg_zero if i is not None]
-        self.assertEqual(whisper.aggregate('avg_zero', non_null, avg_zero), 1.25)
         # avg_zero without neighborValues
-
+        self.assertEqual(whisper.aggregate('avg_zero', non_null, avg_zero), 1.25)
+        # absmax with negative max
+        self.assertEqual(whisper.aggregate('absmax', [-3, -2, 1, 2]), -3)
+        # absmax with positive max
+        self.assertEqual(whisper.aggregate('absmax', [-2, -1, 2, 3]), 3)
         with self.assertRaises(whisper.InvalidAggregationMethod):
             whisper.aggregate('avg_zero', non_null)
 

--- a/test_whisper.py
+++ b/test_whisper.py
@@ -188,14 +188,18 @@ class TestWhisper(WhisperTestBase):
         self.assertEqual(whisper.aggregate('average', [1, 2, 3, 4]), 2.5)
         avg_zero = [1, 2, 3, 4, None, None, None, None]
         non_null = [i for i in avg_zero if i is not None]
-        # avg_zero without neighborValues
         self.assertEqual(whisper.aggregate('avg_zero', non_null, avg_zero), 1.25)
+        # avg_zero without neighborValues
+        with self.assertRaises(whisper.InvalidAggregationMethod):
+            whisper.aggregate('avg_zero', non_null)
         # absmax with negative max
         self.assertEqual(whisper.aggregate('absmax', [-3, -2, 1, 2]), -3)
         # absmax with positive max
         self.assertEqual(whisper.aggregate('absmax', [-2, -1, 2, 3]), 3)
-        with self.assertRaises(whisper.InvalidAggregationMethod):
-            whisper.aggregate('avg_zero', non_null)
+        # absmin with positive min
+        self.assertEqual(whisper.aggregate('absmin', [-3, -2, 1, 2]), 1)
+        # absmin with negative min
+        self.assertEqual(whisper.aggregate('absmin', [-2, -1, 2, 3]), -1)
 
         with AssertRaisesException(whisper.InvalidAggregationMethod('Unrecognized aggregation method derp')):
             whisper.aggregate('derp', [12, 2, 3123, 1])

--- a/whisper.py
+++ b/whisper.py
@@ -113,7 +113,8 @@ aggregationTypeToMethod = dict({
   4: 'max',
   5: 'min',
   6: 'avg_zero',
-  7: 'absmax'
+  7: 'absmax',
+  8: 'absmin'
 })
 aggregationMethodToType = dict([[v, k] for k, v in aggregationTypeToMethod.items()])
 aggregationMethods = aggregationTypeToMethod.values()
@@ -470,12 +471,9 @@ def aggregate(aggregationMethod, knownValues, neighborValues=None):
     values = [x or 0 for x in neighborValues]
     return float(sum(values)) / float(len(values))
   elif aggregationMethod == 'absmax':
-    maxValue = max(knownValues)
-    minValue = min(knownValues)
-    if abs(minValue) > maxValue:
-      return minValue
-    else:
-      return maxValue
+    return max(knownValues, key=abs)
+  elif aggregationMethod == 'absmin':
+    return min(knownValues, key=abs)
   else:
     raise InvalidAggregationMethod("Unrecognized aggregation method %s" %
             aggregationMethod)

--- a/whisper.py
+++ b/whisper.py
@@ -112,7 +112,8 @@ aggregationTypeToMethod = dict({
   3: 'last',
   4: 'max',
   5: 'min',
-  6: 'avg_zero'
+  6: 'avg_zero',
+  7: 'absmax'
 })
 aggregationMethodToType = dict([[v, k] for k, v in aggregationTypeToMethod.items()])
 aggregationMethods = aggregationTypeToMethod.values()
@@ -468,6 +469,13 @@ def aggregate(aggregationMethod, knownValues, neighborValues=None):
         raise InvalidAggregationMethod("Using avg_zero without neighborValues")
     values = [x or 0 for x in neighborValues]
     return float(sum(values)) / float(len(values))
+  elif aggregationMethod == 'absmax':
+    maxValue = max(knownValues)
+    minValue = min(knownValues)
+    if abs(minValue) > maxValue:
+      return minValue
+    else:
+      return maxValue
   else:
     raise InvalidAggregationMethod("Unrecognized aggregation method %s" %
             aggregationMethod)


### PR DESCRIPTION
absmax is a new aggregation method which returns the largest
absolute value when aggregating to a lower precision archive.

Useful for data such as time offsets, where you care about retaining
the value furthest from zero when aggregating but would prefer to
preserve whether the offset was positive or negative.
