### PR TITLE
whisper-lastupdate: add utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ Options:
   --pretty       Show human-readable timestamps instead of unix times
 ```
 
+whisper-lastupdate.py
+----------------
+Display the most recently stored metric to stdout.
+
+```
+Usage: whisper-lastupdate.py [options] path
+
+Options:
+  -h, --help     show this help message and exit
+  --json         Output results in JSON form
+  --pretty       Show human-readable timestamps instead of unix times
+```
+
 whisper-info.py
 ---------------
 

--- a/bin/whisper-lastupdate.py
+++ b/bin/whisper-lastupdate.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+
+import sys
+import time
+import signal
+import optparse
+
+try:
+  import whisper
+except ImportError:
+  raise SystemExit('[ERROR] Please make sure whisper is installed properly')
+
+# Ignore SIGPIPE
+signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+now = int( time.time() )
+
+option_parser = optparse.OptionParser(usage='''%prog [options] path''')
+option_parser.add_option('--json', default=False, action='store_true',
+  help="Output results in JSON form")
+option_parser.add_option('--pretty', default=False, action='store_true',
+  help="Show human-readable timestamps instead of unix times")
+
+(options, args) = option_parser.parse_args()
+
+if len(args) != 1:
+  option_parser.print_help()
+  sys.exit(1)
+
+path = args[0]
+
+try:
+  last_update = whisper.fetch_lastupdate(path, now)
+except whisper.WhisperException, exc:
+  raise SystemExit('[ERROR] %s' % str(exc))
+
+if last_update is None:
+  last_update = (0, None)
+
+(t, v) = last_update
+
+if options.json:
+  value_json = str(v).replace('None','null')
+  print '''{
+  "timestamp" : %d,
+  "value" : %s
+}''' % (t, value_json)
+  sys.exit(0)
+
+if options.pretty:
+  timestr = time.ctime(t)
+else:
+  timestr = str(t)
+if v is None:
+  valuestr = "None"
+else:
+  valuestr = "%f" % v
+print "%s\t%s" % (timestr, valuestr)


### PR DESCRIPTION
This provides whisper with a capability similar to "rrdtool lastupdate": it returns the timestamp and value of the last metric added to the database.  The utility can be used by a monitoring system to determine whether updates are still being received.

(I realize the search is potentially inefficient if, in fact, the database is not fairly current.  However this implementation intentionally has minimal impact on the existing implementation.  whisper would need some refactoring in both implementation and architecture to get something better.)