### PR TITLE
fix write optimization in update_many

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -654,9 +654,10 @@ def __archive_update_many(fh,header,archive,points):
   packedStrings = []
   previousInterval = None
   currentString = ""
-  for i in xrange(0,len(alignedPoints)):
+  lenAlignedPoints = len(alignedPoints)
+  for i in xrange(0,lenAlignedPoints):
     #take last point in run of points with duplicate intervals
-    if i+1 < len(alignedPoints) and alignedPoints[i][0] == alignedPoints[i+1][0]:
+    if i+1 < lenAlignedPoints and alignedPoints[i][0] == alignedPoints[i+1][0]:
       continue
     (interval,value) = alignedPoints[i]
     if (not previousInterval) or (interval == previousInterval + step):


### PR DESCRIPTION
Current code at line 653 uses dict() to remove duplicates. This works, but it leaves the list of points not in interval order. Later runs of contiguous points are batched together into a packed string so they can be write() at once. But because the list is out of order, this batching work is defeated, leaving many batches with just on point in them.

This fix removes the dict() call and uses last value in run of points with duplicate intervals during the loop that creates the list of packed strings for batching.
