### PR TITLE
create: unlink the file we've created if ENOSPC

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -362,51 +362,54 @@ aggregationMethod specifies the function to use when propogating data (see ``whi
     raise InvalidConfiguration("File %s already exists!" % path)
 
   fh = open(path,'wb')
-  if LOCK:
-    fcntl.flock( fh.fileno(), fcntl.LOCK_EX )
-
-  aggregationType = struct.pack( longFormat, aggregationMethodToType.get(aggregationMethod, 1) )
-  oldest = max([secondsPerPoint * points for secondsPerPoint,points in archiveList])
-  maxRetention = struct.pack( longFormat, oldest )
-  xFilesFactor = struct.pack( floatFormat, float(xFilesFactor) )
-  archiveCount = struct.pack(longFormat, len(archiveList))
-  packedMetadata = aggregationType + maxRetention + xFilesFactor + archiveCount
-  fh.write(packedMetadata)
-  headerSize = metadataSize + (archiveInfoSize * len(archiveList))
-  archiveOffsetPointer = headerSize
-
-  for secondsPerPoint,points in archiveList:
-    archiveInfo = struct.pack(archiveInfoFormat, archiveOffsetPointer, secondsPerPoint, points)
-    fh.write(archiveInfo)
-    archiveOffsetPointer += (points * pointSize)
-
-  #If configured to use fallocate and capable of fallocate use that, else
-  #attempt sparse if configure or zero pre-allocate if sparse isn't configured.
-  if CAN_FALLOCATE and useFallocate:
-    remaining = archiveOffsetPointer - headerSize
-    fallocate(fh, headerSize, remaining)
-  elif sparse:
-    fh.seek(archiveOffsetPointer - 1)
-    fh.write('\x00')
-  else:
-    remaining = archiveOffsetPointer - headerSize
-    chunksize = 16384
-    zeroes = '\x00' * chunksize
-    while remaining > chunksize:
-      fh.write(zeroes)
-      remaining -= chunksize
-    fh.write(zeroes[:remaining])
-
-  if AUTOFLUSH:
-    fh.flush()
-    os.fsync(fh.fileno())
-
   try:
+    if LOCK:
+      fcntl.flock( fh.fileno(), fcntl.LOCK_EX )
+  
+    aggregationType = struct.pack( longFormat, aggregationMethodToType.get(aggregationMethod, 1) )
+    oldest = max([secondsPerPoint * points for secondsPerPoint,points in archiveList])
+    maxRetention = struct.pack( longFormat, oldest )
+    xFilesFactor = struct.pack( floatFormat, float(xFilesFactor) )
+    archiveCount = struct.pack(longFormat, len(archiveList))
+    packedMetadata = aggregationType + maxRetention + xFilesFactor + archiveCount
+    fh.write(packedMetadata)
+    headerSize = metadataSize + (archiveInfoSize * len(archiveList))
+    archiveOffsetPointer = headerSize
+  
+    for secondsPerPoint,points in archiveList:
+      archiveInfo = struct.pack(archiveInfoFormat, archiveOffsetPointer, secondsPerPoint, points)
+      fh.write(archiveInfo)
+      archiveOffsetPointer += (points * pointSize)
+  
+    #If configured to use fallocate and capable of fallocate use that, else
+    #attempt sparse if configure or zero pre-allocate if sparse isn't configured.
+    if CAN_FALLOCATE and useFallocate:
+      remaining = archiveOffsetPointer - headerSize
+      fallocate(fh, headerSize, remaining)
+    elif sparse:
+      fh.seek(archiveOffsetPointer - 1)
+      fh.write('\x00')
+    else:
+      remaining = archiveOffsetPointer - headerSize
+      chunksize = 16384
+      zeroes = '\x00' * chunksize
+      while remaining > chunksize:
+        fh.write(zeroes)
+        remaining -= chunksize
+      fh.write(zeroes[:remaining])
+  
+    if AUTOFLUSH:
+      fh.flush()
+      os.fsync(fh.fileno())
+  
     fh.close()
   except IOError, e:
     # Cleanup after ourself if there's no space left on device
     if e.errno == ENOSPC:
       os.unlink(fh.name)
+    # double close is ok - the first one is needed to catch ENOSPC on close
+    # This one closes the file if we caught an IOError higher up
+    fh.close()
     raise
 
 


### PR DESCRIPTION
Instead of leaving a 0 byte empty/corrupted whisper file on the filesystem, unlink the file we've just created if we encounter a ENOSPC error.
This allows carbon to retry the creation later when we might have some free space.

I've seen this problem a few times:
 - the FS fills up because of carbon creating new whisper files
 - eventually the OS returns ENOSPC
 - At that point carbon is simply creating empty files (0 byte) in the file hierarchy
 - When trying to query those new metrics, graphite gets a `CorruptWhisperFile` since the header cannot be read.
 - You then have to go through the file system and remove empty wsp files to let carbon dump its cached metrics.

The code is similar in master so it probably needs the fix too, but the code has diverged a bit so the patch won't apply directly. 

An easy way to test this is by using a really small `tmpfs` on linux:
```
mkdir /tmp/blah
sudo mount -t tmpfs -o size=10  tmpfs /tmp/blah
```

and then create a few whisper files:
```
import whisper

whisper.create('/tmp/blah/test1.wsp', [(1, 1000)])  # should get ENOSPC while writing to file

whisper.create('/tmp/blah/test1.wsp', [(1, 100)])  # should work
whisper.create('/tmp/blah/test2.wsp', [(1, 100)])  # Should get ENOSPC in fh.close()
```