### PR TITLE
create: unlink the file we've created on ENOSPC  (master)

### DIFF
--- a/test_whisper.py
+++ b/test_whisper.py
@@ -198,7 +198,8 @@ class TestWhisper(WhisperTestBase):
         method = getattr(m_file, ioerror_method)
         method.side_effect = IOError(e, "Mocked IOError - ENOSPC")
 
-        with patch('whisper.open', m_open, create=True), patch('os.unlink') as m_unlink:
+        with patch('whisper.open', m_open, create=True):
+          with patch('os.unlink') as m_unlink:
             self.assertRaises(IOError, whisper.create, self.filename, self.retention)
             if test_unlink:
                 m_unlink.assert_called_with(self.filename)

--- a/whisper.py
+++ b/whisper.py
@@ -32,6 +32,8 @@ import struct
 import operator
 import itertools
 
+from errno import ENOSPC
+
 try:
   import fcntl
   CAN_LOCK = True
@@ -376,44 +378,52 @@ aggregationMethod specifies the function to use when propagating data (see ``whi
     raise InvalidConfiguration("File %s already exists!" % path)
 
   with open(path,'wb') as fh:
-    if LOCK:
-      fcntl.flock( fh.fileno(), fcntl.LOCK_EX )
-
-    aggregationType = struct.pack( longFormat, aggregationMethodToType.get(aggregationMethod, 1) )
-    oldest = max([secondsPerPoint * points for secondsPerPoint,points in archiveList])
-    maxRetention = struct.pack( longFormat, oldest )
-    xFilesFactor = struct.pack( floatFormat, float(xFilesFactor) )
-    archiveCount = struct.pack(longFormat, len(archiveList))
-    packedMetadata = aggregationType + maxRetention + xFilesFactor + archiveCount
-    fh.write(packedMetadata)
-    headerSize = metadataSize + (archiveInfoSize * len(archiveList))
-    archiveOffsetPointer = headerSize
-
-    for secondsPerPoint,points in archiveList:
-      archiveInfo = struct.pack(archiveInfoFormat, archiveOffsetPointer, secondsPerPoint, points)
-      fh.write(archiveInfo)
-      archiveOffsetPointer += (points * pointSize)
-
-    #If configured to use fallocate and capable of fallocate use that, else
-    #attempt sparse if configure or zero pre-allocate if sparse isn't configured.
-    if CAN_FALLOCATE and useFallocate:
-      remaining = archiveOffsetPointer - headerSize
-      fallocate(fh, headerSize, remaining)
-    elif sparse:
-      fh.seek(archiveOffsetPointer - 1)
-      fh.write('\x00')
-    else:
-      remaining = archiveOffsetPointer - headerSize
-      chunksize = 16384
-      zeroes = '\x00' * chunksize
-      while remaining > chunksize:
-        fh.write(zeroes)
-        remaining -= chunksize
-      fh.write(zeroes[:remaining])
-
-    if AUTOFLUSH:
-      fh.flush()
-      os.fsync(fh.fileno())
+    try:
+      if LOCK:
+        fcntl.flock( fh.fileno(), fcntl.LOCK_EX )
+  
+      aggregationType = struct.pack( longFormat, aggregationMethodToType.get(aggregationMethod, 1) )
+      oldest = max([secondsPerPoint * points for secondsPerPoint,points in archiveList])
+      maxRetention = struct.pack( longFormat, oldest )
+      xFilesFactor = struct.pack( floatFormat, float(xFilesFactor) )
+      archiveCount = struct.pack(longFormat, len(archiveList))
+      packedMetadata = aggregationType + maxRetention + xFilesFactor + archiveCount
+      fh.write(packedMetadata)
+      headerSize = metadataSize + (archiveInfoSize * len(archiveList))
+      archiveOffsetPointer = headerSize
+  
+      for secondsPerPoint,points in archiveList:
+        archiveInfo = struct.pack(archiveInfoFormat, archiveOffsetPointer, secondsPerPoint, points)
+        fh.write(archiveInfo)
+        archiveOffsetPointer += (points * pointSize)
+  
+      #If configured to use fallocate and capable of fallocate use that, else
+      #attempt sparse if configure or zero pre-allocate if sparse isn't configured.
+      if CAN_FALLOCATE and useFallocate:
+        remaining = archiveOffsetPointer - headerSize
+        fallocate(fh, headerSize, remaining)
+      elif sparse:
+        fh.seek(archiveOffsetPointer - 1)
+        fh.write('\x00')
+      else:
+        remaining = archiveOffsetPointer - headerSize
+        chunksize = 16384
+        zeroes = '\x00' * chunksize
+        while remaining > chunksize:
+          fh.write(zeroes)
+          remaining -= chunksize
+        fh.write(zeroes[:remaining])
+  
+      if AUTOFLUSH:
+        fh.flush()
+        os.fsync(fh.fileno())
+      # Explicitly close the file to catch IOError on close()
+      fh.close()
+    except IOError, e:
+      # Cleanup after ourself if there's no space left on device
+      if e.errno == ENOSPC:
+        os.unlink(fh.name)
+      raise
 
 
 def aggregate(aggregationMethod, knownValues):


### PR DESCRIPTION
Instead of leaving a 0 byte or corrupted whisper file on the filesystem,
this allows carbon to retry the creation later when we might have some free space.

Same fix as in #105 .

This is basically wrapping the body of `create()` in a try/except IOError, and unlinking the file if we caught ENOSPC.
The file is explicitly closed in the try/except to catch IOError on close(), which is a edge case that can happen. (see the tests cases in #105 )