### PR TITLE
0.9.x - create: unlink new file on any IOError types

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -404,12 +404,14 @@ aggregationMethod specifies the function to use when propogating data (see ``whi
   
     fh.close()
   except IOError, e:
-    # Cleanup after ourself if there's no space left on device
-    if e.errno == ENOSPC:
+    try:
+      # if we got an IOError above, the file is either empty or half created.
+      # Better off deleting it to avoid surprises later
       os.unlink(fh.name)
-    # double close is ok - the first one is needed to catch ENOSPC on close
-    # This one closes the file if we caught an IOError higher up
-    fh.close()
+    finally:
+      # double close is ok - the first one is needed to catch ENOSPC on close
+      # This one closes the file if we caught an IOError higher up
+      fh.close()
     raise
 
 


### PR DESCRIPTION
Same as #108 , but for 0.9.x.

Using a `finally` clause to make sure the file is closed no matter what happens in `os.unlink()`.
Master didn't need this since it is using `with open(foo) as fh`