### PR TITLE
Backport to 0.9.x enforce closing of files

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -257,34 +257,32 @@ def setAggregationMethod(path, aggregationMethod):
 path is a string
 aggregationMethod specifies the method to use when propogating data (see ``whisper.aggregationMethods``)
 """
-  fh = open(path,'r+b')
-  if LOCK:
-    fcntl.flock( fh.fileno(), fcntl.LOCK_EX )
+  with open(path,'r+b') as fh:
+    if LOCK:
+      fcntl.flock( fh.fileno(), fcntl.LOCK_EX )
 
-  packedMetadata = fh.read(metadataSize)
+    packedMetadata = fh.read(metadataSize)
 
-  try:
-    (aggregationType,maxRetention,xff,archiveCount) = struct.unpack(metadataFormat,packedMetadata)
-  except:
-    raise CorruptWhisperFile("Unable to read header", fh.name)
+    try:
+      (aggregationType,maxRetention,xff,archiveCount) = struct.unpack(metadataFormat,packedMetadata)
+    except:
+      raise CorruptWhisperFile("Unable to read header", fh.name)
 
-  try:
-    newAggregationType = struct.pack( longFormat, aggregationMethodToType[aggregationMethod] )
-  except KeyError:
-    raise InvalidAggregationMethod("Unrecognized aggregation method: %s" %
-          aggregationMethod)
+    try:
+      newAggregationType = struct.pack( longFormat, aggregationMethodToType[aggregationMethod] )
+    except KeyError:
+      raise InvalidAggregationMethod("Unrecognized aggregation method: %s" %
+            aggregationMethod)
 
-  fh.seek(0)
-  fh.write(newAggregationType)
+    fh.seek(0)
+    fh.write(newAggregationType)
 
-  if AUTOFLUSH:
-    fh.flush()
-    os.fsync(fh.fileno())
+    if AUTOFLUSH:
+      fh.flush()
+      os.fsync(fh.fileno())
 
-  if CACHE_HEADERS and fh.name in __headerCache:
-    del __headerCache[fh.name]
-
-  fh.close()
+    if CACHE_HEADERS and fh.name in __headerCache:
+      del __headerCache[fh.name]
 
   return aggregationTypeToMethod.get(aggregationType, 'average')
 
@@ -361,58 +359,58 @@ aggregationMethod specifies the function to use when propogating data (see ``whi
   if os.path.exists(path):
     raise InvalidConfiguration("File %s already exists!" % path)
 
-  fh = open(path,'wb')
-  try:
-    if LOCK:
-      fcntl.flock( fh.fileno(), fcntl.LOCK_EX )
-  
-    aggregationType = struct.pack( longFormat, aggregationMethodToType.get(aggregationMethod, 1) )
-    oldest = max([secondsPerPoint * points for secondsPerPoint,points in archiveList])
-    maxRetention = struct.pack( longFormat, oldest )
-    xFilesFactor = struct.pack( floatFormat, float(xFilesFactor) )
-    archiveCount = struct.pack(longFormat, len(archiveList))
-    packedMetadata = aggregationType + maxRetention + xFilesFactor + archiveCount
-    fh.write(packedMetadata)
-    headerSize = metadataSize + (archiveInfoSize * len(archiveList))
-    archiveOffsetPointer = headerSize
-  
-    for secondsPerPoint,points in archiveList:
-      archiveInfo = struct.pack(archiveInfoFormat, archiveOffsetPointer, secondsPerPoint, points)
-      fh.write(archiveInfo)
-      archiveOffsetPointer += (points * pointSize)
-  
-    #If configured to use fallocate and capable of fallocate use that, else
-    #attempt sparse if configure or zero pre-allocate if sparse isn't configured.
-    if CAN_FALLOCATE and useFallocate:
-      remaining = archiveOffsetPointer - headerSize
-      fallocate(fh, headerSize, remaining)
-    elif sparse:
-      fh.seek(archiveOffsetPointer - 1)
-      fh.write('\x00')
-    else:
-      remaining = archiveOffsetPointer - headerSize
-      chunksize = 16384
-      zeroes = '\x00' * chunksize
-      while remaining > chunksize:
-        fh.write(zeroes)
-        remaining -= chunksize
-      fh.write(zeroes[:remaining])
-  
-    if AUTOFLUSH:
-      fh.flush()
-      os.fsync(fh.fileno())
-  
-    fh.close()
-  except IOError, e:
+  with open(path,'wb') as fh:
     try:
-      # if we got an IOError above, the file is either empty or half created.
-      # Better off deleting it to avoid surprises later
-      os.unlink(fh.name)
-    finally:
-      # double close is ok - the first one is needed to catch ENOSPC on close
-      # This one closes the file if we caught an IOError higher up
+      if LOCK:
+        fcntl.flock( fh.fileno(), fcntl.LOCK_EX )
+  
+      aggregationType = struct.pack( longFormat, aggregationMethodToType.get(aggregationMethod, 1) )
+      oldest = max([secondsPerPoint * points for secondsPerPoint,points in archiveList])
+      maxRetention = struct.pack( longFormat, oldest )
+      xFilesFactor = struct.pack( floatFormat, float(xFilesFactor) )
+      archiveCount = struct.pack(longFormat, len(archiveList))
+      packedMetadata = aggregationType + maxRetention + xFilesFactor + archiveCount
+      fh.write(packedMetadata)
+      headerSize = metadataSize + (archiveInfoSize * len(archiveList))
+      archiveOffsetPointer = headerSize
+  
+      for secondsPerPoint,points in archiveList:
+        archiveInfo = struct.pack(archiveInfoFormat, archiveOffsetPointer, secondsPerPoint, points)
+        fh.write(archiveInfo)
+        archiveOffsetPointer += (points * pointSize)
+  
+      #If configured to use fallocate and capable of fallocate use that, else
+      #attempt sparse if configure or zero pre-allocate if sparse isn't configured.
+      if CAN_FALLOCATE and useFallocate:
+        remaining = archiveOffsetPointer - headerSize
+        fallocate(fh, headerSize, remaining)
+      elif sparse:
+        fh.seek(archiveOffsetPointer - 1)
+        fh.write('\x00')
+      else:
+        remaining = archiveOffsetPointer - headerSize
+        chunksize = 16384
+        zeroes = '\x00' * chunksize
+        while remaining > chunksize:
+          fh.write(zeroes)
+          remaining -= chunksize
+        fh.write(zeroes[:remaining])
+  
+      if AUTOFLUSH:
+        fh.flush()
+        os.fsync(fh.fileno())
+  
       fh.close()
-    raise
+    except IOError, e:
+      try:
+        # if we got an IOError above, the file is either empty or half created.
+        # Better off deleting it to avoid surprises later
+        os.unlink(fh.name)
+      finally:
+        # double close is ok - the first one is needed to catch ENOSPC on close
+        # This one closes the file if we caught an IOError higher up
+        fh.close()
+      raise
 
 
 def aggregate(aggregationMethod, knownValues):
@@ -520,8 +518,8 @@ value is a float
 timestamp is either an int or float
 """
   value = float(value)
-  fh = open(path,'r+b')
-  return file_update(fh, value, timestamp)
+  with open(path,'r+b') as fh:
+    return file_update(fh, value, timestamp)
 
 
 def file_update(fh, value, timestamp):
@@ -574,8 +572,6 @@ def file_update(fh, value, timestamp):
     fh.flush()
     os.fsync(fh.fileno())
 
-  fh.close()
-
 
 def update_many(path,points):
   """update_many(path,points)
@@ -586,8 +582,8 @@ points is a list of (timestamp,value) points
   if not points: return
   points = [ (int(t),float(v)) for (t,v) in points]
   points.sort(key=lambda p: p[0],reverse=True) #order points by timestamp, newest first
-  fh = open(path,'r+b')
-  return file_update_many(fh, points)
+  with open(path,'r+b') as fh:
+    return file_update_many(fh, points)
 
 
 def file_update_many(fh, points):
@@ -626,8 +622,6 @@ def file_update_many(fh, points):
   if AUTOFLUSH:
     fh.flush()
     os.fsync(fh.fileno())
-
-  fh.close()
 
 
 def __archive_update_many(fh,header,archive,points):
@@ -706,9 +700,8 @@ def info(path):
 
 path is a string
 """
-  fh = open(path,'rb')
-  info = __readHeader(fh)
-  fh.close()
+  with open(path,'rb') as fh:
+    info = __readHeader(fh)
   return info
 
 
@@ -724,8 +717,8 @@ where timeInfo is itself a tuple of (fromTime, untilTime, step)
 
 Returns None if no data can be returned
 """
-  fh = open(path,'rb')
-  return file_fetch(fh, fromTime, untilTime, now)
+  with open(path,'rb') as fh:
+    return file_fetch(fh, fromTime, untilTime, now)
 
 
 def file_fetch(fh, fromTime, untilTime, now = None):
@@ -815,7 +808,6 @@ def file_fetch(fh, fromTime, untilTime, now = None):
       valueList[i/2] = pointValue #in-place reassignment is faster than append()
     currentInterval += step
 
-  fh.close()
   timeInfo = (fromInterval,untilInterval,step)
   return (timeInfo,valueList)
 


### PR DESCRIPTION
The original commit:
    f610a6505a76df4f4dca9099c0d9c6824b80cb57

This was cleaned up significantly on the master branch.  This is a
backport that wraps open files using Python's with statement to ensure
that opened files are always closed.

This solves a bug that I encountered where a traceback would occur in
whisper.update_many() leaving the .wsp file unclosed and flock()'d.  The
Python GC would not reclaim the out of scope file descriptor and close the
file before carbon-cache's writer thread needed to update the same .wsp
file again.  Issue #129