### PR TITLE
Handle zero length time ranges by returning the next valid point

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -757,6 +757,10 @@ def file_fetch(fh, fromTime, untilTime, now = None):
 
   fromInterval = int( fromTime - (fromTime % archive['secondsPerPoint']) ) + archive['secondsPerPoint']
   untilInterval = int( untilTime - (untilTime % archive['secondsPerPoint']) ) + archive['secondsPerPoint']
+  if fromInterval == untilInterval:
+    # Check for zero-length time rages and always include the next point
+    untilInterval = untilInterval + archive['secondsPerPoint']
+
   fh.seek(archive['offset'])
   packedPoint = fh.read(pointSize)
   (baseInterval,baseValue) = struct.unpack(pointFormat,packedPoint)


### PR DESCRIPTION
This appears to match current behavior when a user requests a time range
between two intervals in the archive.  The next valid point is returned
even though its outside the initial time range.

Previously, as untilInterval was not greater than fromInterval the code
would do a wrap-read of the archive reading all data points into memory
and would return the correct timeInfo but a very long array of Nones for
values.  This resulted in very large pickle objects being exchanged
between graphite webapps and very long query times.