### PR TITLE
whisper-auto-resize.py: Fixed broken detection of changed xFilesFactor and added better handling for special chars in file paths

### DIFF
--- a/contrib/whisper-auto-resize.py
+++ b/contrib/whisper-auto-resize.py
@@ -142,14 +142,9 @@ def processMetric(fullPath, schemas, agg_schemas):
         rebuild = True
         messages += '%s aggregation schema differs real: %s should be: %s \n' % (metric, info['aggregationMethod'], aggregationMethod)
 
-    # check to see if the current and configured xFilesFactor are the same
-    if (xFilesFactor != info['xFilesFactor']):
-        rebuild = True
-        messages += '%s xFilesFactor differs real: %s should be: %s \n' % (metric, info['xFilesFactor'], xFilesFactor)
-
     # if we need to rebuild, lets do it.
     if (rebuild == True):
-        cmd = 'whisper-resize.py "%s" %s --xFilesFactor=%s --aggregationMethod=%s %s' % (fullPath, options.extra_args, xFilesFactor, aggregationMethod, schema_config_args)
+        cmd = "whisper-resize.py '%s' %s --xFilesFactor=%s --aggregationMethod=%s %s" % (fullPath, options.extra_args, xFilesFactor, aggregationMethod, schema_config_args)
         if (options.quiet != True or options.confirm == True):
             print(messages)
             print(cmd)


### PR DESCRIPTION
* Floats were not properly compared when checking the xFilesFactor (well, they were, but then a worse check was made afterwards).
* Using single quotes for invoking whisper-resize.py to properly handle file paths with $ in them (don't ask me why we have them...)