### PR TITLE
Wrong boundary when searching archive (0.9.x)

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -750,7 +750,7 @@ def file_fetch(fh, fromTime, untilTime, now = None):
   if untilTime > now:
     untilTime = now
 
-  diff = now - fromTime
+  diff = untilTime - fromTime
   for archive in header['archives']:
     if archive['retention'] >= diff:
       break


### PR DESCRIPTION
This appears to be a _very_ old bug where we use the wrong "until" boundary when searching for the proper archive. Discussed with a few reviewers, everyone agrees this looks like the intended behavior. No obvious regressions in testing.

/cc @deniszh @SEJeff @jjneely 