### PR TITLE
Revert "using the wrong until boundary"

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -750,7 +750,7 @@ def file_fetch(fh, fromTime, untilTime, now = None):
   if untilTime > now:
     untilTime = now
 
-  diff = untilTime - fromTime
+  diff = now - fromTime
   for archive in header['archives']:
     if archive['retention'] >= diff:
       break


### PR DESCRIPTION
This reverts commit 5725d4dc061cd9ea40c1a6371f48d5bc762d6e9a. Fixes #144.