### PR TITLE
Fix whisper-fetch so the --drop parameter works

### DIFF
--- a/bin/whisper-fetch.py
+++ b/bin/whisper-fetch.py
@@ -57,7 +57,7 @@ except whisper.WhisperException as exc:
 
 if options.drop:
     fcn = _DROP_FUNCTIONS.get(options.drop)
-    values = [ fcn(x) for x in values ]
+    values = [ x for x in values if fcn(x) ]
 
 (start,end,step) = timeInfo
 


### PR DESCRIPTION
Previously the code was using the results of the boolean filter function as the value, rather than using it to select which points to print out.