### PR TITLE
Stop testing python2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 
 python:
-  - 2.6
   - 2.7
   - pypy
   - 3.2
@@ -25,7 +24,7 @@ script:
   - bin/whisper-update.py --help
   - contrib/whisper-auto-update.py --help
   - contrib/whisper-auto-resize.py --help
-  - "if echo $TRAVIS_PYTHON_VERSION | egrep -q '^(2.6|pypy)$'; then pip install unittest2 --use-mirrors; fi"
+  - "if echo $TRAVIS_PYTHON_VERSION | egrep -q '^pypy$'; then pip install unittest2 --use-mirrors; fi"
   # Coverage of tests ensures we don't have dead coded in the tests
   - coverage run --include='whisper.py,test_whisper.py' test_whisper.py
 after_success:


### PR DESCRIPTION
Twisted 15.5 officially breaks Python 2.6 support so let's stop testing it.

refs https://github.com/graphite-project/carbon/issues/482