### PR TITLE
(fix) [FreeBSD-i386] correct size of off_t in posix_fallocate call

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -60,6 +60,10 @@ if CAN_FALLOCATE:
   c_off64_t = ctypes.c_int64
   c_off_t = ctypes.c_int
 
+  if os.uname()[0] == 'FreeBSD':
+    # offset type is 64-bit on FreeBSD 32-bit & 64-bit platforms to address files more than 2GB
+    c_off_t = ctypes.c_int64
+
   try:
     _fallocate = libc.posix_fallocate64
     _fallocate.restype = ctypes.c_int


### PR DESCRIPTION
Hi,

On i386 FreeBSD, whisper doesn't work. When carbon tries to create new metric file, it's failed with short message like: "error to create file". ktrace showed that fallocate call is failed and arguments are corrupted. The reason is that size of "off_t" type is 64 bits on all FreeBSD platform, but whisper tried to use int32 (as for Linux 32bit).

Please review patch and commit it!

Feel free to ask questions.

Thank you! 