### PR TITLE
Fixed error in determining which archive to use when there are multip…

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -790,7 +790,7 @@ def file_fetch(fh, fromTime, untilTime, now=None):
   if untilTime > now:
     untilTime = now
 
-  diff = untilTime - fromTime
+  diff = now - fromTime
   for archive in header['archives']:
     if archive['retention'] >= diff:
       break


### PR DESCRIPTION
…le archives

One should use "now" instead of "untilTime" when calculating diff value
untilTime does not have sense here, it is important to know how far is "fromTime"
from "now" to find which arhive period to use
For ex. if you have such configuration

```
Archive 0
retention: 604800 (7 days)
secondsPerPoint: 10

Archive 1
retention: 2592000 (30 days)
secondsPerPoint: 60
```

fromTime: now - 8 days
untilTime: now - 6 days

```
// 2 days is lesser then 7 days, this leads to Archive 0 and is NOT correct
diff = untilTime - fromTime

//  8 days is greater then 7 days and lead to Archive 1 and IS correct
diff = now - fromTime
```