### PR TITLE
Timestamps in cache

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -240,6 +240,7 @@ def enableDebug():
 def __readHeader(fh):
   if CACHE_HEADERS:
     info = __headerCache.get(fh.name).info
+    __headerCache.get(fh.name).time = time.time()
     if info:
       return info
 

--- a/whisper.py
+++ b/whisper.py
@@ -86,6 +86,17 @@ CACHE_HEADERS = False
 AUTOFLUSH = False
 __headerCache = {}
 
+class HeaderCacheEntry():
+    name = None
+    info = None
+    time = None
+
+    def __init__(name, info, time):
+        self.name = name
+        self.info = info
+        self.time = time
+
+
 longFormat = "!L"
 longSize = struct.calcsize(longFormat)
 floatFormat = "!f"
@@ -228,7 +239,7 @@ def enableDebug():
 
 def __readHeader(fh):
   if CACHE_HEADERS:
-    info = __headerCache.get(fh.name)
+    info = __headerCache.get(fh.name).info
     if info:
       return info
 
@@ -267,7 +278,7 @@ def __readHeader(fh):
     'archives': archives,
   }
   if CACHE_HEADERS:
-    __headerCache[fh.name] = info
+    __headerCache[fh.name] = HeaderCacheEntry(fh.name, info, time.time())
 
   return info
 

--- a/whisper.py
+++ b/whisper.py
@@ -91,7 +91,7 @@ class HeaderCacheEntry():
     info = None
     time = None
 
-    def __init__(name, info, time):
+    def __init__(self, name, info, time):
         self.name = name
         self.info = info
         self.time = time
@@ -239,11 +239,9 @@ def enableDebug():
 
 def __readHeader(fh):
   if CACHE_HEADERS:
-    info = __headerCache.get(fh.name).info
-    __headerCache.get(fh.name).time = time.time()
-    if info:
-      return info
-
+    if fh.name in __headerCache:
+        __headerCache.get(fh.name).time = time.time()
+        return __headerCache.get(fh.name).info
   originalOffset = fh.tell()
   fh.seek(0)
   packedMetadata = fh.read(metadataSize)


### PR DESCRIPTION
Creates a notion of a header cache entry to encapsulate the info section along with time, this can be used to age out the entry
