### PR TITLE
rrd2whisper.py: Only suffix wsp files if required

### DIFF
--- a/bin/rrd2whisper.py
+++ b/bin/rrd2whisper.py
@@ -103,7 +103,8 @@ for rra in relevant_rras:
 
 for datasource in datasources:
   now = int(time.time())
-  path = rrd_path.replace('.rrd', '_%s.wsp' % datasource)
+  suffix = '_%s' % datasource if len(datasources) > 1 else ''
+  path = rrd_path.replace('.rrd', '%s.wsp' % suffix)
   try:
     whisper.create(path, archives, xFilesFactor=xFilesFactor)
   except whisper.InvalidConfiguration as e:


### PR DESCRIPTION
Whisper files created by rrd2whisper should only be suffixed with the RRD data source name if more than one data source is defined in the RRD file.

Background: I converted a bunch of Munin RRDs into whisper format and all of the files were suffixed with `_2` which was not especially convenient.