### PR TITLE
allow for optional comparison of source and destination directories 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,15 @@ already present in the target file, but instead, only add the missing
 data (e.g. where the gaps in the target file are).  Because no values
 are overwritten, no data or precision gets lost.  Also, unlike
 whisper-merge, try to take the highest-precision archive to provide
-the data, instead of the one with the largest retention.
+the data, instead of the one with the largest retention. If the source
+and destination are both directories, recursive comparison is performed
+on filename patterns, and appropriate backfilling is done in a multi
+threaded fashion (Handy if you have lots of files to fill).
 
 ```
-Usage: whisper-fill.py [options] src_path dst_path
+Usage: whisper-fill.py [options] src_file_path dst_file_path
+ *or*
+Usage: whisper-fill.py [options] src_dir_path dst_dir_path
 
 Options:
   -h, --help  show this help message and exit

--- a/bin/whisper-fill.py
+++ b/bin/whisper-fill.py
@@ -150,7 +150,6 @@ def main():
 
         src = args[0]
         dst = args[1]
-        print('DEBUG: src: %s dst: %s' % (src, dst))
         
         # if our src *AND* dst are directories we'll want to walk them
         # to get our file list, setup our worker pool, and start goin

--- a/bin/whisper-fill.py
+++ b/bin/whisper-fill.py
@@ -175,6 +175,8 @@ def main():
                     if os.path.isfile('%s%s' % (dst, sf.split(src)[1])):
                         fills.append((dst, sf.split(src)[1], time.time()))
                         
+            print('Processing %d files with 8 workers.' % len(fills))
+            
             # And now that we have a list of files to backfill, let's get
             # cracking
             results = pool.map(wrap_fill_archives, fills)

--- a/bin/whisper-fill.py
+++ b/bin/whisper-fill.py
@@ -131,7 +131,8 @@ def list_files(tgt):
         return False
 
 def wrap_fill_archives(data):
-    fill_archives(data[0], data[1], data[2])
+    fill_archives('/'.join((data[0], data[2])), '/'.join((data[1], data[2])), data[3])
+    sys.stdout.write('.')
 
 def main():
         option_parser = optparse.OptionParser(
@@ -172,7 +173,7 @@ def main():
                 # off backfills.
                 for sf in src_f:
                     if os.path.isfile('%s%s' % (dst, sf.split(src)[1])):
-                        fills.append((dst, sf.split(src)[1], time.time()))
+                        fills.append((src, dst, sf.split(src)[1], time.time()))
                         
             print('Processing %d files with 8 workers.' % len(fills))
             
@@ -181,6 +182,7 @@ def main():
             results = pool.map(wrap_fill_archives, fills)
             pool.close()
             pool.join()
+            print('')
         else:
             startFrom = time.time()
             fill_archives(src, dst, startFrom)


### PR DESCRIPTION
All original functionality is untouched, but if you need to backfill a large directory of files, firing off a python instance for every single one of them wastes a ton of resources.
