### PR TITLE
contrib, whisper-auto-resize: define default values for xFilesFactor and aggregationMethod

### DIFF
--- a/contrib/whisper-auto-resize.py
+++ b/contrib/whisper-auto-resize.py
@@ -109,9 +109,12 @@ def processMetric(fullPath, schemas, agg_schemas):
             archive_config = [archive.getTuple() for archive in schema.archives]
             break
 
+    xFilesFactor = 0.5
+    aggregationMethod = 'average'
+
     # loop through the carbon-aggregation schemas
     for agg_schema in agg_schemas:
-        if agg_schema.matches(metric):
+        if agg_schema.matches(metric) and all(x is not None for x in agg_schema.archives):
             xFilesFactor, aggregationMethod = agg_schema.archives
             break
 


### PR DESCRIPTION

trying to fix the following trace:

Traceback (most recent call last):
  File "/tmp/whisper-auto-resize.py", line 208, in <module>
    processMetric(fullpath, schemas, agg_schemas)
  File "/tmp/whisper-auto-resize.py", line 136, in processMetric
    str_xFilesFactor =  "{0:.2f}".format(xFilesFactor)
ValueError: Unknown format code 'f' for object of type 'str'

when xFilesFactor and aggregationMethod is not defined in configuration for a specfic data subdir
use default values defined in documentation

Signed-off-by: William Dauchy <w.dauchy@criteo.com>