### PR TITLE
fix three bugs making aggregation impossible in whisper-resize.py

### DIFF
--- a/bin/whisper-resize.py
+++ b/bin/whisper-resize.py
@@ -112,16 +112,7 @@ if options.aggregate:
     # Loading all datapoints into memory for fast querying
     timeinfo, values = archive['data']
     new_datapoints = zip( range(*timeinfo), values )
-    if all_datapoints:
-      last_timestamp = all_datapoints[-1][0]
-      slice_end = 0
-      for i,(timestamp,value) in enumerate(new_datapoints):
-        if timestamp > last_timestamp:
-          slice_end = i
-          break
-      all_datapoints += new_datapoints[i:]
-    else:
-      all_datapoints += new_datapoints
+    all_datapoints += new_datapoints
 
   oldtimestamps = map( lambda p: p[0], all_datapoints)
   oldvalues = map( lambda p: p[1], all_datapoints)
@@ -132,11 +123,12 @@ if options.aggregate:
 
   new_info = whisper.info(newfile)
   new_archives = new_info['archives']
+  new_archives.sort(key=lambda a: a['secondsPerPoint'], reverse=True)
 
   for archive in new_archives:
     step = archive['secondsPerPoint']
-    fromTime = now - archive['retention'] + now % step
-    untilTime = now + now % step + step
+    fromTime = now - archive['retention'] - now % step
+    untilTime = now - now % step + step
     print("(%s,%s,%s)" % (fromTime,untilTime, step))
     timepoints_to_update = range(fromTime, untilTime, step)
     print("timepoints_to_update: %s" % timepoints_to_update)


### PR DESCRIPTION
I was in the situation that I have to resize a number of around 30.000 whisper files to match another retention time. Because I needed the average and not only a single value picked in a defined interval I tried using the aggregation feature of whisper-resize.py. But it wasn't working at all. The newly created whisper file was broken and the data unusable.
In most cases there was a loss of data for the smallest retention time and some other ugly bugs for bigger retention times. Also it could happen that you lose only a few timestamps but in a regular pattern.
So in most of the cases the old version was shredding your data. This PR is fixing this issue. It was testet on the 30.000 whisper files I have to resize and and in a few other constellation. So it seems working in all use cases.
