### PR TITLE
Add optional destinationPath for rrd2whisper

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Options:
                         The consolidation function to fetch from on input and
                         aggregationMethod to set on output. One of: average,
                         last, max, min
+  --destinationPath=DESTINATIONPATH
+                        Path to place created whisper file. Defaults to the
+                        RRD file's source path.
 ```
 
 whisper-create.py


### PR DESCRIPTION
I've found it super helpful to be able to pass a destination path to rrd2whisper so the new whisper file can be created in a different directory. This PR adds an optional argument to specify a destination path. Let me know what you think. 