### PR TITLE
whisper-auto-resize: fix default values for xFilesFactor and aggregat…

### DIFF
--- a/contrib/whisper-auto-resize.py
+++ b/contrib/whisper-auto-resize.py
@@ -119,14 +119,16 @@ def processMetric(fullPath, schemas, agg_schemas):
             archive_config = [archive.getTuple() for archive in schema.archives]
             break
 
-    xFilesFactor = 0.5
-    aggregationMethod = 'average'
-
     # loop through the carbon-aggregation schemas
     for agg_schema in agg_schemas:
-        if agg_schema.matches(metric) and all(x is not None for x in agg_schema.archives):
+        if agg_schema.matches(metric):
             xFilesFactor, aggregationMethod = agg_schema.archives
             break
+
+    if xFilesFactor is None:
+        xFilesFactor = 0.5
+    if aggregationMethod is None:
+        aggregationMethod = 'average'
 
     # loop through the bucket tuples and convert to string format for resizing
     for retention in archive_config:


### PR DESCRIPTION
…ionMethod

the condition was wrong when agg_schema was either defined for xFilesFactor
or aggregationMethod
in this case the default values were always used

Test each value separately to resolve the issue

Fixes: 32b1b6b4d9b (contrib, whisper-auto-resize: define default values
       for xFilesFactor and aggregationMethod)
Signed-off-by: William Dauchy <w.dauchy@criteo.com>