### PR TITLE
Fix indentation on CACHE_HEADERS, not related to AUTOFLUSH

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -330,8 +330,8 @@ xFilesFactor specifies the fraction of data points in a propagation interval tha
       fh.flush()
       os.fsync(fh.fileno())
 
-      if CACHE_HEADERS and fh.name in __headerCache:
-        del __headerCache[fh.name]
+    if CACHE_HEADERS and fh.name in __headerCache:
+      del __headerCache[fh.name]
 
   return aggregationTypeToMethod.get(aggregationType, 'average')
 


### PR DESCRIPTION
This makes it identical to how 0.9.x is now. cache headers should be cleaned unregarding from autoflush.