### PR TITLE
Make indentation consistent in files with mixed indentation

### DIFF
--- a/bin/whisper-create.py
+++ b/bin/whisper-create.py
@@ -20,10 +20,10 @@ def byte_format(num):
 
 # Ignore SIGPIPE
 try:
-   signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+  signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 except AttributeError:
-   #OS=windows
-   pass
+  #OS=windows
+  pass
 
 option_parser = optparse.OptionParser(
     usage='''%prog path timePerPoint:timeToStore [timePerPoint:timeToStore]*
@@ -77,8 +77,8 @@ archives = [whisper.parseRetentionDef(retentionDef)
             for retentionDef in args[1:]]
 
 if os.path.exists(path) and options.overwrite:
-    print('Overwriting existing file: %s' % path)
-    os.unlink(path)
+  print('Overwriting existing file: %s' % path)
+  os.unlink(path)
 
 try:
   whisper.create(path, archives, xFilesFactor=options.xFilesFactor, aggregationMethod=options.aggregationMethod, sparse=options.sparse, useFallocate=options.fallocate)

--- a/bin/whisper-dump.py
+++ b/bin/whisper-dump.py
@@ -13,7 +13,7 @@ except ImportError:
   raise SystemExit('[ERROR] Please make sure whisper is installed properly')
 
 if sys.version_info >= (3, 0):
-    xrange = range
+  xrange = range
 
 # Ignore SIGPIPE
 signal.signal(signal.SIGPIPE, signal.SIG_DFL)

--- a/bin/whisper-fetch.py
+++ b/bin/whisper-fetch.py
@@ -56,8 +56,8 @@ except whisper.WhisperException as exc:
   raise SystemExit('[ERROR] %s' % str(exc))
 
 if options.drop:
-    fcn = _DROP_FUNCTIONS.get(options.drop)
-    values = [ x for x in values if fcn(x) ]
+  fcn = _DROP_FUNCTIONS.get(options.drop)
+  values = [ x for x in values if fcn(x) ]
 
 (start,end,step) = timeInfo
 

--- a/bin/whisper-merge.py
+++ b/bin/whisper-merge.py
@@ -30,7 +30,7 @@ path_from = args[0]
 path_to = args[1]
 
 for filename in (path_from, path_to):
-   if not os.path.exists(filename):
-       raise SystemExit('[ERROR] File "%s" does not exist!' % filename)
+  if not os.path.exists(filename):
+    raise SystemExit('[ERROR] File "%s" does not exist!' % filename)
 
 whisper.merge(path_from, path_to, options._from, options.until)

--- a/bin/whisper-set-aggregation-method.py
+++ b/bin/whisper-set-aggregation-method.py
@@ -6,9 +6,9 @@ import signal
 import optparse
 
 try:
-    import whisper
+  import whisper
 except ImportError:
-    raise SystemExit('[ERROR] Please make sure whisper is installed properly')
+  raise SystemExit('[ERROR] Please make sure whisper is installed properly')
 
 # Ignore SIGPIPE
 try:

--- a/whisper.py
+++ b/whisper.py
@@ -37,7 +37,7 @@ izip = getattr(itertools, 'izip', zip)
 ifilter = getattr(itertools, 'ifilter', filter)
 
 if sys.version_info >= (3, 0):
-    xrange = range
+  xrange = range
 
 try:
   import fcntl
@@ -138,8 +138,8 @@ UnitMultipliers = {
 
 def getUnitString(s):
   for value in ('seconds', 'minutes', 'hours', 'days', 'weeks', 'years'):
-      if value.startswith(s):
-          return value
+    if value.startswith(s):
+      return value
   raise ValueError("Invalid unit '%s'" % s)
 
 
@@ -171,27 +171,27 @@ def parseRetentionDef(retentionDef):
 
 class WhisperException(Exception):
 
-    """Base class for whisper exceptions."""
+  """Base class for whisper exceptions."""
 
 
 class InvalidConfiguration(WhisperException):
 
-    """Invalid configuration."""
+  """Invalid configuration."""
 
 
 class InvalidAggregationMethod(WhisperException):
 
-    """Invalid aggregation method."""
+  """Invalid aggregation method."""
 
 
 class InvalidTimeInterval(WhisperException):
 
-    """Invalid time interval."""
+  """Invalid time interval."""
 
 
 class TimestampNotCovered(WhisperException):
 
-    """Timestamp not covered by any archives in this database."""
+  """Timestamp not covered by any archives in this database."""
 
 
 class CorruptWhisperFile(WhisperException):
@@ -311,11 +311,11 @@ xFilesFactor specifies the fraction of data points in a propagation interval tha
             aggregationMethod)
 
     if xFilesFactor is not None:
-        # Use specified xFilesFactor
-        xff = struct.pack(floatFormat, float(xFilesFactor))
+      # Use specified xFilesFactor
+      xff = struct.pack(floatFormat, float(xFilesFactor))
     else:
-        # Retain old value
-        xff = struct.pack(floatFormat, xff)
+      # Retain old value
+      xff = struct.pack(floatFormat, xff)
 
     # Repack the remaining header information
     maxRetention = struct.pack(longFormat, maxRetention)
@@ -472,7 +472,7 @@ def aggregate(aggregationMethod, knownValues, neighborValues=None):
     return min(knownValues)
   elif aggregationMethod == 'avg_zero':
     if not neighborValues:
-        raise InvalidAggregationMethod("Using avg_zero without neighborValues")
+      raise InvalidAggregationMethod("Using avg_zero without neighborValues")
     values = [x or 0 for x in neighborValues]
     return float(sum(values)) / float(len(values))
   else:
@@ -683,7 +683,7 @@ def file_update_many(fh, points):
 def __archive_update_many(fh, header, archive, points):
   step = archive['secondsPerPoint']
   alignedPoints = [(timestamp - (timestamp % step), value)
-                    for (timestamp, value) in points]
+                   for (timestamp, value) in points]
   # Create a packed string for each contiguous sequence of points
   packedStrings = []
   previousInterval = None
@@ -964,9 +964,9 @@ def file_diff(fh_from, fh_to, ignore_empty=False, until_time=None):
 
   now = int(time.time())
   if until_time:
-      untilTime = until_time
+    untilTime = until_time
   else:
-      untilTime = now
+    untilTime = now
 
   for archive_number, archive in enumerate(archives):
     diffs = []


### PR DESCRIPTION
I'm having trouble with my OCD by just looking at the files which mix indentation. Some files have a mix of two, four or even three spaces. 

This patch sets the indentation to two spaces on all files with mixed indentation. This is just aesthetic It should not change any logic. I didn't touch the files which have a consistent four space indentation.

I would rather update everything to 4 spaces to comply with pep8 and add flake8 test, but don't know if that will get merged as that would change almost every line of code.