### PR TITLE
Add whisper-set-xfilesfactor.py 

### DIFF
--- a/bin/rrd2whisper.py
+++ b/bin/rrd2whisper.py
@@ -41,7 +41,7 @@ option_parser.add_option(
 option_parser.add_option('--destinationPath', 
     help="Path to place created whisper file. Defaults to the " + 
     "RRD file's source path.",
-    default='.', 
+    default=None,
     type='string')
 
 (options, args) = option_parser.parse_args()
@@ -120,7 +120,7 @@ for datasource in datasources:
           pass
         else: raise
     rrd_file = os.path.basename(rrd_path).replace('.rrd', '%s.wsp' % suffix)
-    path = os.path.dirname(destination_path) + '/' + rrd_file
+    path = destination_path + '/' + rrd_file
   else:
     path = rrd_path.replace('.rrd', '%s.wsp' % suffix)
 

--- a/bin/whisper-set-xfilesfactor.py
+++ b/bin/whisper-set-xfilesfactor.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import sys
+import argparse
+import whisper
+
+
+def main():
+    """Set xFilesFactor for existing whisper file"""
+    parser = argparse.ArgumentParser(
+        description='Set xFilesFactor for existing whisper file')
+    parser.add_argument('path', type=str, help='path to whisper file')
+    parser.add_argument('xff', metavar='xFilesFactor', type=float,
+                        help='new xFilesFactor, a float between 0 and 1')
+
+    args = parser.parse_args()
+
+    try:
+        old_xff = whisper.setXFilesFactor(args.path, args.xff)
+    except IOError:
+        sys.stderr.write("[ERROR] File '%s' does not exist!\n\n" % args.path)
+        parser.print_help()
+        sys.exit(1)
+    except whisper.WhisperException as exc:
+        raise SystemExit('[ERROR] %s' % str(exc))
+
+    print('Updated xFilesFactor: %s (%s -> %s)' %
+          (args.path, old_xff, args.xff))
+
+if __name__ == "__main__":
+    main()

--- a/test_whisper.py
+++ b/test_whisper.py
@@ -515,7 +515,9 @@ class TestWhisper(WhisperTestBase):
 
         target_xff = 0.42
         info0 = whisper.info(self.filename)
-        whisper.setXFilesFactor(self.filename, target_xff)
+        old_xff = whisper.setXFilesFactor(self.filename, target_xff)
+        # return value should match old xff
+        self.assertEqual(info0['xFilesFactor'], old_xff)
         info1 = whisper.info(self.filename)
 
         # Other header information should not change
@@ -599,7 +601,10 @@ class TestWhisper(WhisperTestBase):
             # original xFilesFactor
             info0 = whisper.info(self.filename)
             # optional xFilesFactor not passed
-            whisper.setAggregationMethod(self.filename, ag)
+            old_ag = whisper.setAggregationMethod(self.filename, ag)
+
+            # should return old aggregationmethod
+            self.assertEqual(old_ag, info0['aggregationMethod'])
 
             # original value should not change
             info1 = whisper.info(self.filename)
@@ -609,7 +614,9 @@ class TestWhisper(WhisperTestBase):
             self.assertEqual(ag, info1['aggregationMethod'])
 
             # optional xFilesFactor used
-            whisper.setAggregationMethod(self.filename, ag, xff)
+            old_ag = whisper.setAggregationMethod(self.filename, ag, xff)
+            # should return old aggregationmethod
+            self.assertEqual(old_ag, info1['aggregationMethod'])
             # new info should match what we just set it to
             info2 = whisper.info(self.filename)
             # packing and unpacking because


### PR DESCRIPTION
Add setXFilesFactor function which changes the XFilesFactor
without modifying the aggregation method.
Refactor setAggregationMethod, split out the writing of header
metadata.
Add validation for writing header medatadat.
test_whisper.py: force rereading header when simulating a
corrupt whisper file