### PR TITLE
parseRetentionDef: raise more descriptive exception on wrong retention

### DIFF
--- a/test_whisper.py
+++ b/test_whisper.py
@@ -678,6 +678,7 @@ class TestParseRetentionDef(unittest.TestCase):
             ('60:10x', ValueError("Invalid unit 'x'")),
 
             # From parseRetentionDef
+            ('10', ValueError("Invalid retention definition '10'")),
             ('10X:10', ValueError("Invalid precision specification '10X'")),
             ('10:10$', ValueError("Invalid retention specification '10$'")),
             ('60:10', (60, 10)),

--- a/whisper.py
+++ b/whisper.py
@@ -144,7 +144,10 @@ def getUnitString(s):
 
 
 def parseRetentionDef(retentionDef):
-  (precision, points) = retentionDef.strip().split(':', 1)
+  try:
+    (precision, points) = retentionDef.strip().split(':', 1)
+  except ValueError:
+    raise ValueError("Invalid retention definition '%s'" % retentionDef)
 
   if precision.isdigit():
     precision = int(precision) * UnitMultipliers[getUnitString('s')]


### PR DESCRIPTION
This returns a more descriptive exception/error message for the user:

old
```
$ python ./bin/whisper-create.py aa.wsp 10
Traceback (most recent call last):
  File "./bin/whisper-create.py", line 77, in <module>
    for retentionDef in args[1:]]
  File "/home/piotr/git/whisper/whisper.py", line 147, in parseRetentionDef
    (precision, points) = retentionDef.strip().split(':', 1)
ValueError: need more than 1 value to unpack
```

new
```
$ python ./bin/whisper-create.py aa.wsp 10
Traceback (most recent call last):
  File "./bin/whisper-create.py", line 77, in <module>
    for retentionDef in args[1:]]
  File "/home/piotr/git/whisper/whisper.py", line 150, in parseRetentionDef
    raise ValueError("Invalid retention definition '%s'" % retentionDef)
ValueError: Invalid retention definition '10'
```