### PR TITLE
whisper resize, don't attempt to merge empty files

### DIFF
--- a/test_whisper.py
+++ b/test_whisper.py
@@ -347,6 +347,22 @@ class TestWhisper(WhisperTestBase):
         whisper.merge(self.filename, testdb)
         self._remove(testdb)
 
+    def test_merge_empty(self):
+        """
+        test merging from an empty database
+        """
+        testdb_a = "test-a-%s" % self.filename
+        testdb_b = "test-b-%s" % self.filename
+
+        # create two empty databases with same retention
+        whisper.create(testdb_a, self.retention)
+        whisper.create(testdb_b, self.retention)
+
+        whisper.merge(testdb_a, testdb_b)
+
+        self._remove(testdb_a)
+        self._remove(testdb_b)
+
     def test_merge_bad_archive_config(self):
         testdb = "test-%s" % self.filename
 

--- a/whisper.py
+++ b/whisper.py
@@ -990,6 +990,9 @@ def file_merge(fh_from, fh_to, time_from=None, time_to=None):
     pointsToWrite = list(ifilter(
       lambda points: points[1] is not None,
       izip(xrange(start, end, archive_step), values)))
+    # skip if there are no points to write
+    if len(pointsToWrite) == 0:
+      continue
     __archive_update_many(fh_to, headerTo, archive, pointsToWrite)
 
 


### PR DESCRIPTION
Fixes following exception:

```
$ python bin/whisper-merge.py aa.wsp bb.wsp 
Traceback (most recent call last):
  File "bin/whisper-merge.py", line 36, in <module>
    whisper.merge(path_from, path_to, options._from, options.until)
  File "/home/piotr/git/whisper/whisper.py", line 951, in merge
    return file_merge(fh_from, fh_to, time_from, time_to)
  File "/home/piotr/git/whisper/whisper.py", line 993, in file_merge
    __archive_update_many(fh_to, headerTo, archive, pointsToWrite)
  File "/home/piotr/git/whisper/whisper.py", line 768, in __archive_update_many
    baseInterval = packedStrings[0][0]  # Use our first string as the base, so we start at the start
IndexError: list index out of range
```