### PR TITLE
whisper-fetch whisper-auto-update: validate if whisper.fetch() returned data

### DIFF
--- a/bin/whisper-fetch.py
+++ b/bin/whisper-fetch.py
@@ -51,7 +51,10 @@ from_time = int( options._from )
 until_time = int( options.until )
 
 try:
-  (timeInfo, values) = whisper.fetch(path, from_time, until_time)
+  data = whisper.fetch(path, from_time, until_time)
+  if not data:
+    raise SystemExit('No data in selected timerange')
+  (timeInfo, values) = data
 except whisper.WhisperException as exc:
   raise SystemExit('[ERROR] %s' % str(exc))
 

--- a/contrib/whisper-auto-update.py
+++ b/contrib/whisper-auto-update.py
@@ -45,7 +45,10 @@ from_time = int( options._from )
 until_time = int( options.until )
 
 try:
-  (timeInfo, values_old) = whisper.fetch(path, from_time, until_time)
+  data = whisper.fetch(path, from_time, until_time)
+  if not data:
+    raise SystemExit('No data in selected timerange')
+  (timeInfo, values_old) = data
 except whisper.WhisperException as exc:
   raise SystemExit('[ERROR] %s' % str(exc))
 


### PR DESCRIPTION
whisper.fetch() returns None if the timeperiod is invalid which results in a TypeError when a tuple is expected:

```
./bin/whisper-fetch.py --from=1 --until=10 aa.wsp
Traceback (most recent call last):
  File "./bin/whisper-fetch.py", line 54, in <module>
    (timeInfo, values) = whisper.fetch(path, from_time, until_time)
TypeError: 'NoneType' object is not iterable
```

I wanted to just raise an exception instead of returning None but it seems this is actually desired behaviour:
https://github.com/graphite-project/whisper/commit/cd389a5f7ba9722e5035703c39027db4fc947ddd
validation in graphite-web:
https://github.com/graphite-project/graphite-web/blob/master/webapp/graphite/readers.py#L185-L187

I've added validation to the cli scripts which take from and until time from user input.