### PR TITLE
Don't open file read+write for diff operation

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -999,7 +999,7 @@ def file_merge(fh_from, fh_to, time_from=None, time_to=None):
 def diff(path_from, path_to, ignore_empty=False, until_time=None):
   """ Compare two whisper databases. Each file must have the same archive configuration """
   with open(path_from, 'rb') as fh_from:
-    with open(path_to, 'rb+') as fh_to:
+    with open(path_to, 'rb') as fh_to:
       return file_diff(fh_from, fh_to, ignore_empty, until_time)
 
 


### PR DESCRIPTION
No need for write access when performing a diff


```
~/g/whisper_2 (master|…) $ chmod 444 bb.wsp
~/g/whisper_2 (master|…) $ ./bin/whisper-diff.py aa.wsp bb.wsp
Traceback (most recent call last):
  File "./bin/whisper-diff.py", line 103, in <module>
    main()
  File "./bin/whisper-diff.py", line 90, in main
    archive_diffs = whisper.diff(path_a,path_b,ignore_empty=options.ignore_empty,until_time=until_time)
  File "/home/piotr/git/whisper_2/whisper.py", line 1002, in diff
    with open(path_to, 'rb+') as fh_to:
IOError: [Errno 13] Permission denied: 'bb.wsp'
```