### PR TITLE
Revert e402

### DIFF
--- a/contrib/whisper-auto-resize.py
+++ b/contrib/whisper-auto-resize.py
@@ -80,7 +80,6 @@ if options.carbonlib is not None:
 
 try:
     from carbon.conf import settings
-    from carbon.storage import loadStorageSchemas, loadAggregationSchemas
 except ImportError:
     raise SystemExit('[ERROR] Can\'t find the carbon module, try using '
                      '--carbonlib to explicitly include the path')
@@ -88,6 +87,9 @@ except ImportError:
 # carbon.conf not seeing the config files so give it a nudge
 settings.CONF_DIR = configPath
 settings.LOCAL_DATA_DIR = storagePath
+
+# import these once we have the settings figured out
+from carbon.storage import loadStorageSchemas, loadAggregationSchemas
 
 # Load the Defined Schemas from our config files
 schemas = loadStorageSchemas()

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
 exclude = .git,__pycache__,build,dist
 max-line-length=100
-ignore=E111,E121,E114
+ignore=E111,E121,E114,E402


### PR DESCRIPTION
Reverts earlier style cleanup which broke whisper-auto-resize. The import order matters, needs to be set after settings.CONF_DIR is set. Added E402 to ignore in tox.ini so that flake8 won't complain.