### PR TITLE
whisper-fetch.py: catch IOError to print a better error message

### DIFF
--- a/bin/whisper-fetch.py
+++ b/bin/whisper-fetch.py
@@ -58,7 +58,7 @@ try:
   if not data:
     raise SystemExit('No data in selected timerange')
   (timeInfo, values) = data
-except whisper.WhisperException as exc:
+except (whisper.WhisperException, IOError) as exc:
   raise SystemExit('[ERROR] %s' % str(exc))
 
 if options.drop:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "../whisper_2/bin/whisper-fetch.py", line 57, in <module>
    data = whisper.fetch(path, from_time, until_time)
  File "/home/piotr/git/carbon/venv3/lib/python3.5/site-packages/whisper.py", line 832, in fetch
    with open(path, 'rb') as fh:
FileNotFoundError: [Errno 2] No such file or directory: 'venv3/storage/whisper/acc/applications/alaal.wsp'
```

VS:
```
[ERROR] [Errno 2] No such file or directory: 'venv3/storage/whisper/acc/applications/alaal.wsp'
```