### PR TITLE
py3 compat: enableDebug and auto-resize, update tox file and pep8

### DIFF
--- a/bin/whisper-create.py
+++ b/bin/whisper-create.py
@@ -19,6 +19,7 @@ def byte_format(num):
     num /= 1024.0
   return "%.3f%s" % (num, 'GB')
 
+
 # Ignore SIGPIPE
 try:
   signal.signal(signal.SIGPIPE, signal.SIG_DFL)

--- a/bin/whisper-diff.py
+++ b/bin/whisper-diff.py
@@ -111,5 +111,6 @@ def main():
       print_diffs(archive_diffs, pretty=(not options.columns),
                   headers=(not options.no_headers))
 
+
 if __name__ == "__main__":
   main()

--- a/bin/whisper-dump.py
+++ b/bin/whisper-dump.py
@@ -105,6 +105,7 @@ def dump_archives(archives):
       offset += whisper.pointSize
     print
 
+
 if not os.path.exists(path):
   raise SystemExit('[ERROR] File "%s" does not exist!' % path)
 

--- a/bin/whisper-set-xfilesfactor.py
+++ b/bin/whisper-set-xfilesfactor.py
@@ -27,5 +27,6 @@ def main():
     print('Updated xFilesFactor: %s (%s -> %s)' %
           (args.path, old_xff, args.xff))
 
+
 if __name__ == "__main__":
     main()

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -172,6 +172,7 @@ def cli_opts():
                         default=False)
     return parser.parse_args()
 
+
 if __name__ == '__main__':
     i_args = cli_opts()
     if os.getenv('USER') != 'root':

--- a/contrib/whisper-auto-resize.py
+++ b/contrib/whisper-auto-resize.py
@@ -6,6 +6,7 @@ from subprocess import call
 from optparse import OptionParser
 from distutils.spawn import find_executable
 from os.path import basename
+from six.moves import input
 
 # On Debian systems whisper-resize.py is available as whisper-resize
 whisperResizeExecutable = find_executable("whisper-resize.py")
@@ -221,12 +222,13 @@ def confirm(question, error_response='Valid options : yes or no'):
              error_response - the message to display if an invalid option is given.
     """
     while True:
-        answer = raw_input(question).lower()
+        answer = input(question).lower()
         if answer in ('y', 'yes'):
             return True
         if answer in ('n', 'no'):
             return False
         print(error_response)
+
 
 if os.path.isfile(processPath) and processPath.endswith('.wsp'):
     processMetric(processPath, schemas, agg_schemas)

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
   description='Fixed size round-robin style database',
   py_modules=['whisper'],
   scripts=glob('bin/*') + glob('contrib/*'),
+  install_requires=['six'],
   classifiers=[
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.6',

--- a/test_whisper.py
+++ b/test_whisper.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
 
 import os
+import sys
 import time
 import math
 import random
 import struct
-
 import errno
+
+from six.moves import StringIO
+from six import assertRegex
 
 try:
     from unittest.mock import patch, mock_open
@@ -660,6 +663,27 @@ class TestWhisper(WhisperTestBase):
         self.assertEqual(fetched[-1], 3.7337)
 
         whisper.LOCK = original_lock
+
+    def test_debug(self):
+        """
+        Test creating a file with debug enabled
+        Should print debug messages to stdout
+        """
+        # debug prints to stdout, redirect it to a variable
+        old_stdout = sys.stdout
+        sys.stdout = StringIO()
+
+        whisper.disableDebug()
+        whisper.enableDebug()
+        self._update()
+        whisper.disableDebug()
+
+        sys.stdout.seek(0)
+        out = sys.stdout.read()
+
+        sys.stdout = old_stdout
+
+        assertRegex(self, out, '(DEBUG :: (WRITE|READ) \d+ bytes #\d+\n)+')
 
     # TODO: This test method takes more time than virtually every
     #       single other test combined. Profile this code and potentially

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,21 @@
+[tox]
+envlist =
+  py27,
+  py34,
+  py35,
+  py36,
+  pypy,
+  lint,
+
+[testenv]
+commands = python -m unittest discover
+deps = mock
+
+[testenv:lint]
+deps = flake8
+commands = flake8 {toxinidir}
+
 [flake8]
-exclude = .git,__pycache__,build,dist
+exclude = .git,__pycache__,build,dist,.tox
 max-line-length=100
 ignore=E111,E121,E114,E402


### PR DESCRIPTION
This makes enableDebug() compatible with python3 and adds testcases. Added option to disable the debug again. Configured tox file to run tests on all active python implementations. Made flake8 pass and updated auto-resize raw_input to support python3.
