### PR TITLE
whisper-dump.py: add --time-format option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ Options:
                  (default: now)
   --json         Output results in JSON form
   --pretty       Show human-readable timestamps instead of unix times
+  -t TIME_FORMAT, --time-format=TIME_FORMAT
+                 Time format to use with --pretty; see time.strftime()
   --drop=DROP    Specify 'nulls' to drop all null values. Specify 'zeroes' to
                  drop all zero values. Specify 'empty' to drop both null and
                  zero values.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Usage: whisper-dump.py path
 
 Options:
   -h, --help  show this help message and exit
+  --pretty    Show human-readable timestamps instead of unix times
+  -t TIME_FORMAT, --time-format=TIME_FORMAT
+              Time format to use with --pretty; see time.strftime()
 ```
 
 whisper-fetch.py

--- a/bin/whisper-fetch.py
+++ b/bin/whisper-fetch.py
@@ -37,6 +37,9 @@ option_parser.add_option(
   '--pretty', default=False, action='store_true',
   help="Show human-readable timestamps instead of unix times")
 option_parser.add_option(
+  '-t', '--time-format', action='store', type='string', dest='time_format',
+  help='Time format to use with --pretty; see time.strftime()')
+option_parser.add_option(
   '--drop', choices=list(_DROP_FUNCTIONS.keys()), action='store',
   help="Specify 'nulls' to drop all null values. "
        "Specify 'zeroes' to drop all zero values. "
@@ -80,7 +83,10 @@ if options.json:
 t = start
 for value in values:
   if options.pretty:
-    timestr = time.ctime(t)
+    if options.time_format:
+      timestr = time.strftime(options.time_format, time.localtime(t))
+    else:
+      timestr = time.ctime(t)
   else:
     timestr = str(t)
   if value is None:


### PR DESCRIPTION
Hi,

This is a simple improvement for those of us who use whisper-dump AND are bad at reading Unix timestamps. Let me know about anything that can be improved.