### PR TITLE
AssertionError fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 *.pyc
 .tox
 .coverage
+coverage.xml
 htmlcov/*
 ve
 .idea

--- a/test_whisper.py
+++ b/test_whisper.py
@@ -401,7 +401,6 @@ class TestWhisper(WhisperTestBase):
 
         whisper.merge(testdb_a, testdb_b)
 
-
     def test_merge_bad_archive_config(self):
         testdb = "test-%s" % self.filename
 
@@ -775,15 +774,14 @@ class TestWhisper(WhisperTestBase):
         retention = [(1, 60), (60, 60), (3600, 24), (86400, 365)]
         whisper.create(self.filename, retention)
 
-        archives = ["1s","1m","1h","1d"]
+        archives = ["1s", "1m", "1h", "1d"]
 
         for i in range(len(archives)):
             fetch = whisper.fetch(self.filename, 0, archiveToSelect=archives[i])
             self.assertEqual(fetch[0][2], retention[i][0])
 
             # check time range
-            self.assertEqual(fetch[0][1] - fetch[0][0],
-                         retention[-1][0] * retention[-1][1])
+            self.assertEqual(fetch[0][1] - fetch[0][0], retention[-1][0] * retention[-1][1])
         with AssertRaisesException(ValueError("Invalid granularity: 2")):
             fetch = whisper.fetch(self.filename, 0, archiveToSelect="2s")
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,13 @@ envlist =
   lint,
 
 [testenv]
-commands = python -m unittest discover
-deps = mock
+commands =
+  coverage run --branch --omit=.tox/* -m unittest discover
+  coverage xml
+  coverage report
+deps =
+  coverage
+  mock
 
 [testenv:lint]
 deps = flake8

--- a/whisper.py
+++ b/whisper.py
@@ -827,8 +827,7 @@ def __archive_update_many(fh, header, archive, points):
 
     if bytesBeyond > 0:
       fh.write(packedString[:-bytesBeyond])
-      assert fh.tell() == (
-        archiveEnd,
+      assert fh.tell() == archiveEnd, (
         "archiveEnd=%d fh.tell=%d bytesBeyond=%d len(packedString)=%d" %
         (archiveEnd, fh.tell(), bytesBeyond, len(packedString))
       )

--- a/whisper.py
+++ b/whisper.py
@@ -921,9 +921,9 @@ def file_fetch(fh, fromTime, untilTime, now=None, archiveToSelect=None):
 
   diff = now - fromTime
 
-  #Parse granularity if requested
+  # Parse granularity if requested
   if archiveToSelect:
-    retentionStr = str(archiveToSelect)+":1"
+    retentionStr = str(archiveToSelect) + ":1"
     archiveToSelect = parseRetentionDef(retentionStr)[0]
 
   for archive in header['archives']:
@@ -936,7 +936,7 @@ def file_fetch(fh, fromTime, untilTime, now=None, archiveToSelect=None):
         break
 
   if archiveToSelect and not archive:
-    raise ValueError("Invalid granularity: %s" %(archiveToSelect))
+    raise ValueError("Invalid granularity: %s" % (archiveToSelect))
 
   return __archive_fetch(fh, archive, fromTime, untilTime)
 


### PR DESCRIPTION
The refactoring in acaacbe introduced a bug which causes an `AssertionError` to be raised in `__archive_update_many`.  This PR fixes the offending line so that the exception is only raised when needed.

I looked at the tests briefly and confirmed that the offending line is not covered, but I'm not sure how to go about adding coverage for it.

This PR also includes a small number of lint fixes, and updates the tox configuration to generate code coverage reports like graphite-web does.