### PR TITLE
Make rrd2whisper.py run with Python 3

### DIFF
--- a/bin/rrd2whisper.py
+++ b/bin/rrd2whisper.py
@@ -20,7 +20,7 @@ except ImportError:
 # Ignore SIGPIPE
 signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
-aggregationMethods = whisper.aggregationMethods
+aggregationMethods = list(whisper.aggregationMethods)
 
 # RRD doesn't have a 'sum' or 'total' type
 aggregationMethods.remove('sum')


### PR DESCRIPTION
The script failed to run because `dict.values()` returned a view rather
than a list in Python 3. See the error message below.

```
Traceback (most recent call last):
  File "/opt/pkg/bin/rrd2whisper.py", line 26, in <module>
    aggregationMethods.remove('sum')
AttributeError: 'dict_values' object has no attribute 'remove'
```