### PR TITLE
Use uname from platform instead of os

### DIFF
--- a/whisper.py
+++ b/whisper.py
@@ -28,6 +28,7 @@
 import itertools
 import operator
 import os
+import platform
 import re
 import struct
 import sys
@@ -69,7 +70,7 @@ if CAN_FALLOCATE:
   c_off64_t = ctypes.c_int64
   c_off_t = ctypes.c_int
 
-  if os.uname()[0] == 'FreeBSD':
+  if platform.uname()[0] == 'FreeBSD':
     # offset type is 64-bit on FreeBSD 32-bit & 64-bit platforms to address files more than 2GB
     c_off_t = ctypes.c_int64
 


### PR DESCRIPTION
platform.uname is a more portable version of uname which should also work on
Windows. It actually tries to call os.uname(), so returning value should be
exactly the same for systems which have os.uname().

fixes: #212