### PR TITLE
[1.1.x] Use uname from platform instead of os | Raise CorruptWhisperFileException when reading datapoints fails (#263)

### DIFF
--- a/bin/whisper-resize.py
+++ b/bin/whisper-resize.py
@@ -172,7 +172,7 @@ os.rename(path, backup)
 try:
   print('Renaming new database to: %s' % path)
   os.rename(tmpfile, path)
-except (OSError, FileNotFoundError, PermissionError):
+except (OSError):
   traceback.print_exc()
   print('\nOperation failed, restoring backup')
   os.rename(backup, path)

--- a/test_whisper.py
+++ b/test_whisper.py
@@ -724,7 +724,7 @@ class TestWhisper(WhisperTestBase):
 
         sys.stdout = old_stdout
 
-        assertRegex(self, out, '(DEBUG :: (WRITE|READ) \d+ bytes #\d+\n)+')
+        assertRegex(self, out, r'(DEBUG :: (WRITE|READ) \d+ bytes #\d+\n)+')
 
     # TODO: This test method takes more time than virtually every
     #       single other test combined. Profile this code and potentially

--- a/tox.ini
+++ b/tox.ini
@@ -39,4 +39,4 @@ commands = flake8 {toxinidir}
 [flake8]
 exclude = .git,__pycache__,build,dist,.tox
 max-line-length=100
-ignore=E111,E121,E114,E402
+ignore=E111,E121,E114,E402,W504

--- a/whisper.py
+++ b/whisper.py
@@ -28,6 +28,7 @@
 import itertools
 import operator
 import os
+import platform
 import re
 import struct
 import sys
@@ -69,7 +70,7 @@ if CAN_FALLOCATE:
   c_off64_t = ctypes.c_int64
   c_off_t = ctypes.c_int
 
-  if os.uname()[0] == 'FreeBSD':
+  if platform.uname()[0] == 'FreeBSD':
     # offset type is 64-bit on FreeBSD 32-bit & 64-bit platforms to address files more than 2GB
     c_off_t = ctypes.c_int64
 


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - Use uname from platform instead of os (#262)
 - Raise CorruptWhisperFileException when reading datapoints fails  (#263)