### PR TITLE
update-storage-times.py enhancements

### DIFF
--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -89,7 +89,7 @@ def fix_metric(metric):
     command_string = list(BASE_COMMAND) + [metric]
 
     retention = DEFAULT_SCHEMA['retentions']
-    matching = metric.replace('/', '.')
+    matching = metric[len(ROOT_PATH):].replace('/', '.')
     for schema, info in SCHEMA_LIST.iteritems():
         if info['match'].search(matching):
             retention = info['retentions']

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -115,9 +115,11 @@ def fix_metric(metric):
         else:
             res = subprocess.check_call(command_string,
                                         stdout=devnull)
+
+        os.chmod(metric, perms)
+        os.chown(metric, owner, group)
+
     devnull.close()
-    os.chmod(metric, perms)
-    os.chown(metric, owner, group)
     # wait for a second, so we don't kill I/O on the host
     time.sleep(0.3)
     """

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -106,12 +106,18 @@ def fix_metric(metric):
         res = 0
     else:
         LOG.debug('Retention will be %s' % retention)
+        # record file owner/group and perms to set properly after whisper-resize.py is complete
+        perms = os.stat(metric).st_mode
+        owner = os.stat(metric).st_uid
+        group = os.stat(metric).st_gid
         if DEBUG:
             res = subprocess.check_call(command_string)
         else:
             res = subprocess.check_call(command_string,
                                         stdout=devnull)
     devnull.close()
+    os.chmod(metric, perms)
+    os.chown(metric, owner, group)
     # wait for a second, so we don't kill I/O on the host
     time.sleep(0.3)
     """
@@ -167,9 +173,9 @@ def cli_opts():
     parser.add_argument('--aggregate', action='store_true', dest='aggregate',
                         help="Passed through to whisper-resize.py, roll up values",
                         default=False)
-    parser.add_argument('--bin-dir', action='store', dest='bin_dir',
+    parser.add_argument('--bindir', action='store', dest='bindir',
                         help="The root path to whisper-resize.py and whisper-info.py",
-                        default='/opt/graphite/bin/')
+                        default='/opt/graphite/bin')
     return parser.parse_args()
 
 
@@ -187,9 +193,9 @@ if __name__ == '__main__':
     ROOT_PATH = i_args.path
     DEBUG = i_args.debug
     DRY_RUN = i_args.dry_run
-    BIN_DIR = i_args.bin_dir
-    RESIZE_BIN = BIN_DIR + "whisper-resize.py"
-    INFO_BIN = BIN_DIR + "whisper-info.py"
+    BINDIR = i_args.bindir
+    RESIZE_BIN = BINDIR + "/whisper-resize.py"
+    INFO_BIN = BINDIR + "/whisper-info.py"
     BASE_COMMAND = [RESIZE_BIN]
 
     if i_args.nobackup:

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -21,8 +21,6 @@ try:
 except ImportError:
     from os import listdir as scandir
 
-RESIZE_BIN = "/opt/graphite/bin/whisper-resize.py"
-INFO_BIN = "/opt/graphite/bin/whisper-info.py"
 LOG = logging.getLogger()
 LOG.setLevel(logging.INFO)
 SCHEMA_LIST = {}
@@ -31,7 +29,6 @@ DEFAULT_SCHEMA = {'match': re.compile('.*'),
                   'retentions': '1m:7d'}
 DEBUG = False
 DRY_RUN = False
-BASE_COMMAND = [RESIZE_BIN]
 ROOT_PATH = ""
 
 
@@ -92,7 +89,7 @@ def fix_metric(metric):
     command_string = list(BASE_COMMAND) + [metric]
 
     retention = DEFAULT_SCHEMA['retentions']
-    matching = metric[len(ROOT_PATH):]
+    matching = metric.replace('/', '.')
     for schema, info in SCHEMA_LIST.iteritems():
         if info['match'].search(matching):
             retention = info['retentions']
@@ -170,6 +167,9 @@ def cli_opts():
     parser.add_argument('--aggregate', action='store_true', dest='aggregate',
                         help="Passed through to whisper-resize.py, roll up values",
                         default=False)
+    parser.add_argument('--bin-dir', action='store', dest='bin_dir',
+                        help="The root path to whisper-resize.py and whisper-info.py",
+                        default='/opt/graphite/bin/')
     return parser.parse_args()
 
 
@@ -187,6 +187,11 @@ if __name__ == '__main__':
     ROOT_PATH = i_args.path
     DEBUG = i_args.debug
     DRY_RUN = i_args.dry_run
+    BIN_DIR = i_args.bin_dir
+    RESIZE_BIN = BIN_DIR + "whisper-resize.py"
+    INFO_BIN = BIN_DIR + "whisper-info.py"
+    BASE_COMMAND = [RESIZE_BIN]
+
     if i_args.nobackup:
         BASE_COMMAND.append('--nobackup')
     if i_args.aggregate:

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -115,7 +115,6 @@ def fix_metric(metric):
         else:
             res = subprocess.check_call(command_string,
                                         stdout=devnull)
-
         os.chmod(metric, perms)
         os.chown(metric, owner, group)
 

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -107,16 +107,14 @@ def fix_metric(metric):
     else:
         LOG.debug('Retention will be %s' % retention)
         # record file owner/group and perms to set properly after whisper-resize.py is complete
-        perms = os.stat(metric).st_mode
-        owner = os.stat(metric).st_uid
-        group = os.stat(metric).st_gid
+        st = os.stat(metric)
         if DEBUG:
             res = subprocess.check_call(command_string)
         else:
             res = subprocess.check_call(command_string,
                                         stdout=devnull)
-        os.chmod(metric, perms)
-        os.chown(metric, owner, group)
+        os.chmod(metric, st.st_mode)
+        os.chown(metric, st.st_uid, st.st_gid)
 
     devnull.close()
     # wait for a second, so we don't kill I/O on the host
@@ -177,6 +175,8 @@ def cli_opts():
     parser.add_argument('--bindir', action='store', dest='bindir',
                         help="The root path to whisper-resize.py and whisper-info.py",
                         default='/opt/graphite/bin')
+    parser.add_argument('--sleep', action='store', dest='sleep',
+                        help="Sleep this amount of time in seconds between metric comparisons")
     return parser.parse_args()
 
 

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -118,7 +118,7 @@ def fix_metric(metric):
 
     devnull.close()
     # wait for a second, so we don't kill I/O on the host
-    time.sleep(0.3)
+    time.sleep(SLEEP)
     """
     We have manual commands for every failed file from these
     errors, so we can just go through each of these errors
@@ -176,7 +176,8 @@ def cli_opts():
                         help="The root path to whisper-resize.py and whisper-info.py",
                         default='/opt/graphite/bin')
     parser.add_argument('--sleep', action='store', dest='sleep',
-                        help="Sleep this amount of time in seconds between metric comparisons")
+                        help="Sleep this amount of time in seconds between metric comparisons",
+                        default=0.3)
     return parser.parse_args()
 
 
@@ -195,6 +196,7 @@ if __name__ == '__main__':
     DEBUG = i_args.debug
     DRY_RUN = i_args.dry_run
     BINDIR = i_args.bindir
+    SLEEP = i_args.sleep
     RESIZE_BIN = BINDIR + "/whisper-resize.py"
     INFO_BIN = BINDIR + "/whisper-info.py"
     BASE_COMMAND = [RESIZE_BIN]


### PR DESCRIPTION
I have added an optional 'bindir' parameter to allow usage of whisper-resize.py and whisper-info.py located in a different directory. Because whisper-resize.py writes the files using the owner/group/umask of the process running the command, and update-storage-times.py throws an error if you are not root I added code to store that info from the original file and apply it to the newly created whisper file after whisper-resize.py is complete. Lastly since storage-schemas are written in dot-delimeted format I updated the matching logic to transpose forward slashes in the metric name to dots for the matching portion.