### PR TITLE
whisper-resize: Don't throw when trying to aggregate a null interval

### DIFF
--- a/bin/whisper-resize.py
+++ b/bin/whisper-resize.py
@@ -149,7 +149,7 @@ if options.aggregate:
       newvalues = oldvalues[lefti:righti]
       if newvalues:
         non_none = filter(lambda x: x is not None, newvalues)
-        if 1.0 * len(non_none) / len(newvalues) >= xff:
+        if non_none and 1.0 * len(non_none) / len(newvalues) >= xff:
           newdatapoints.append([tinterval[0],
                                 whisper.aggregate(aggregationMethod,
                                                   non_none, newvalues)])


### PR DESCRIPTION
While trying to aggregate values during a resize, we ended up with lots of errors because of null intervals. I'm trying to replicate the behaviour in whisper.__propagate where null intervals are not considered for aggregation independently of xFilesFactor.