### PR TITLE
Add codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,5 @@ script:
   - tox -e $TOXENV
 
 after_success:
-  coveralls
+  - pip install codecov
+  - codecov

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/f00d0b65802742e29de56f3744503ab0)](https://www.codacy.com/app/graphite-project/whisper?utm_source=github.com&utm_medium=referral&utm_content=graphite-project/whisper&utm_campaign=badger)
 [![Build Status](https://secure.travis-ci.org/graphite-project/whisper.png)](http://travis-ci.org/graphite-project/whisper)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphite-project%2Fwhisper.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fgraphite-project%2Fwhisper?ref=badge_shield)
+[![codecov](https://codecov.io/gh/graphite-project/whisper/branch/master/graph/badge.svg)](https://codecov.io/gh/graphite-project/whisper)
 
 ## Overview
 


### PR DESCRIPTION
I accidentally broke coveralls in https://github.com/graphite-project/whisper/pull/257/files . 

I don't know if there was a specific reason for using coveralls as graphite-web and carbon both use codecov. Aadded codecov to be consistent.