### PR TITLE
[1.1.x] refactored update-storage-times.py to allow alternate whisper-resize.py and whisper-info.py location, modified matching to convert filesystem path to graphite dot-style used in storage-schemas | recor

### DIFF
--- a/bin/whisper-resize.py
+++ b/bin/whisper-resize.py
@@ -110,7 +110,7 @@ if options.aggregate:
   for archive in old_archives:
     # Loading all datapoints into memory for fast querying
     timeinfo, values = archive['data']
-    new_datapoints = zip(range(*timeinfo), values)
+    new_datapoints = list(zip(range(*timeinfo), values))
     if all_datapoints:
       last_timestamp = all_datapoints[-1][0]
       slice_end = 0
@@ -122,8 +122,8 @@ if options.aggregate:
     else:
       all_datapoints += new_datapoints
 
-  oldtimestamps = map(lambda p: p[0], all_datapoints)
-  oldvalues = map(lambda p: p[1], all_datapoints)
+  oldtimestamps = list(map(lambda p: p[0], all_datapoints))
+  oldvalues = list(map(lambda p: p[1], all_datapoints))
 
   print("oldtimestamps: %s" % oldtimestamps)
   # Simply cleaning up some used memory
@@ -148,7 +148,7 @@ if options.aggregate:
       righti = bisect.bisect_left(oldtimestamps, tinterval[1], lo=lefti)
       newvalues = oldvalues[lefti:righti]
       if newvalues:
-        non_none = filter(lambda x: x is not None, newvalues)
+        non_none = list(filter(lambda x: x is not None, newvalues))
         if non_none and 1.0 * len(non_none) / len(newvalues) >= xff:
           newdatapoints.append([tinterval[0],
                                 whisper.aggregate(aggregationMethod,

--- a/bin/whisper-resize.py
+++ b/bin/whisper-resize.py
@@ -149,7 +149,7 @@ if options.aggregate:
       newvalues = oldvalues[lefti:righti]
       if newvalues:
         non_none = filter(lambda x: x is not None, newvalues)
-        if 1.0 * len(non_none) / len(newvalues) >= xff:
+        if non_none and 1.0 * len(non_none) / len(newvalues) >= xff:
           newdatapoints.append([tinterval[0],
                                 whisper.aggregate(aggregationMethod,
                                                   non_none, newvalues)])

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -89,7 +89,7 @@ def fix_metric(metric):
     command_string = list(BASE_COMMAND) + [metric]
 
     retention = DEFAULT_SCHEMA['retentions']
-    matching = metric.replace('/', '.')
+    matching = metric[len(ROOT_PATH):].replace('/', '.')
     for schema, info in SCHEMA_LIST.iteritems():
         if info['match'].search(matching):
             retention = info['retentions']

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -115,9 +115,11 @@ def fix_metric(metric):
         else:
             res = subprocess.check_call(command_string,
                                         stdout=devnull)
+
+        os.chmod(metric, perms)
+        os.chown(metric, owner, group)
+
     devnull.close()
-    os.chmod(metric, perms)
-    os.chown(metric, owner, group)
     # wait for a second, so we don't kill I/O on the host
     time.sleep(0.3)
     """

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -106,12 +106,18 @@ def fix_metric(metric):
         res = 0
     else:
         LOG.debug('Retention will be %s' % retention)
+        # record file owner/group and perms to set properly after whisper-resize.py is complete
+        perms = os.stat(metric).st_mode
+        owner = os.stat(metric).st_uid
+        group = os.stat(metric).st_gid
         if DEBUG:
             res = subprocess.check_call(command_string)
         else:
             res = subprocess.check_call(command_string,
                                         stdout=devnull)
     devnull.close()
+    os.chmod(metric, perms)
+    os.chown(metric, owner, group)
     # wait for a second, so we don't kill I/O on the host
     time.sleep(0.3)
     """
@@ -167,9 +173,9 @@ def cli_opts():
     parser.add_argument('--aggregate', action='store_true', dest='aggregate',
                         help="Passed through to whisper-resize.py, roll up values",
                         default=False)
-    parser.add_argument('--bin-dir', action='store', dest='bin_dir',
+    parser.add_argument('--bindir', action='store', dest='bindir',
                         help="The root path to whisper-resize.py and whisper-info.py",
-                        default='/opt/graphite/bin/')
+                        default='/opt/graphite/bin')
     return parser.parse_args()
 
 
@@ -187,9 +193,9 @@ if __name__ == '__main__':
     ROOT_PATH = i_args.path
     DEBUG = i_args.debug
     DRY_RUN = i_args.dry_run
-    BIN_DIR = i_args.bin_dir
-    RESIZE_BIN = BIN_DIR + "whisper-resize.py"
-    INFO_BIN = BIN_DIR + "whisper-info.py"
+    BINDIR = i_args.bindir
+    RESIZE_BIN = BINDIR + "/whisper-resize.py"
+    INFO_BIN = BINDIR + "/whisper-info.py"
     BASE_COMMAND = [RESIZE_BIN]
 
     if i_args.nobackup:

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -21,8 +21,6 @@ try:
 except ImportError:
     from os import listdir as scandir
 
-RESIZE_BIN = "/opt/graphite/bin/whisper-resize.py"
-INFO_BIN = "/opt/graphite/bin/whisper-info.py"
 LOG = logging.getLogger()
 LOG.setLevel(logging.INFO)
 SCHEMA_LIST = {}
@@ -31,7 +29,6 @@ DEFAULT_SCHEMA = {'match': re.compile('.*'),
                   'retentions': '1m:7d'}
 DEBUG = False
 DRY_RUN = False
-BASE_COMMAND = [RESIZE_BIN]
 ROOT_PATH = ""
 
 
@@ -92,7 +89,7 @@ def fix_metric(metric):
     command_string = list(BASE_COMMAND) + [metric]
 
     retention = DEFAULT_SCHEMA['retentions']
-    matching = metric[len(ROOT_PATH):]
+    matching = metric.replace('/', '.')
     for schema, info in SCHEMA_LIST.iteritems():
         if info['match'].search(matching):
             retention = info['retentions']
@@ -170,6 +167,9 @@ def cli_opts():
     parser.add_argument('--aggregate', action='store_true', dest='aggregate',
                         help="Passed through to whisper-resize.py, roll up values",
                         default=False)
+    parser.add_argument('--bin-dir', action='store', dest='bin_dir',
+                        help="The root path to whisper-resize.py and whisper-info.py",
+                        default='/opt/graphite/bin/')
     return parser.parse_args()
 
 
@@ -187,6 +187,11 @@ if __name__ == '__main__':
     ROOT_PATH = i_args.path
     DEBUG = i_args.debug
     DRY_RUN = i_args.dry_run
+    BIN_DIR = i_args.bin_dir
+    RESIZE_BIN = BIN_DIR + "whisper-resize.py"
+    INFO_BIN = BIN_DIR + "whisper-info.py"
+    BASE_COMMAND = [RESIZE_BIN]
+
     if i_args.nobackup:
         BASE_COMMAND.append('--nobackup')
     if i_args.aggregate:

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -115,7 +115,6 @@ def fix_metric(metric):
         else:
             res = subprocess.check_call(command_string,
                                         stdout=devnull)
-
         os.chmod(metric, perms)
         os.chown(metric, owner, group)
 

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -107,16 +107,14 @@ def fix_metric(metric):
     else:
         LOG.debug('Retention will be %s' % retention)
         # record file owner/group and perms to set properly after whisper-resize.py is complete
-        perms = os.stat(metric).st_mode
-        owner = os.stat(metric).st_uid
-        group = os.stat(metric).st_gid
+        st = os.stat(metric)
         if DEBUG:
             res = subprocess.check_call(command_string)
         else:
             res = subprocess.check_call(command_string,
                                         stdout=devnull)
-        os.chmod(metric, perms)
-        os.chown(metric, owner, group)
+        os.chmod(metric, st.st_mode)
+        os.chown(metric, st.st_uid, st.st_gid)
 
     devnull.close()
     # wait for a second, so we don't kill I/O on the host
@@ -177,6 +175,8 @@ def cli_opts():
     parser.add_argument('--bindir', action='store', dest='bindir',
                         help="The root path to whisper-resize.py and whisper-info.py",
                         default='/opt/graphite/bin')
+    parser.add_argument('--sleep', action='store', dest='sleep',
+                        help="Sleep this amount of time in seconds between metric comparisons")
     return parser.parse_args()
 
 

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -118,7 +118,7 @@ def fix_metric(metric):
 
     devnull.close()
     # wait for a second, so we don't kill I/O on the host
-    time.sleep(0.3)
+    time.sleep(SLEEP)
     """
     We have manual commands for every failed file from these
     errors, so we can just go through each of these errors
@@ -176,7 +176,8 @@ def cli_opts():
                         help="The root path to whisper-resize.py and whisper-info.py",
                         default='/opt/graphite/bin')
     parser.add_argument('--sleep', action='store', dest='sleep',
-                        help="Sleep this amount of time in seconds between metric comparisons")
+                        help="Sleep this amount of time in seconds between metric comparisons",
+                        default=0.3)
     return parser.parse_args()
 
 
@@ -195,6 +196,7 @@ if __name__ == '__main__':
     DEBUG = i_args.debug
     DRY_RUN = i_args.dry_run
     BINDIR = i_args.bindir
+    SLEEP = i_args.sleep
     RESIZE_BIN = BINDIR + "/whisper-resize.py"
     INFO_BIN = BINDIR + "/whisper-info.py"
     BASE_COMMAND = [RESIZE_BIN]


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - refactored update-storage-times.py to allow alternate whisper-resize.py and whisper-info.py location, modified matching to convert filesystem path to graphite dot-style used in storage-schemas (#265)
 - record and appy perms/ownership after whisper-resize.py is complete, renamed BIN_DIR and variants to BINDIR/bindir to be syntacticly similar to other variables (#265)
 - moving chmod/chown to appropriate location (#265)
 - moving chmod/chown to appropriate location (#265)
 - it's tuple time (#265)
 - Adding back the removal of storage path from metric name (#265)
 - adding SLEEP variable to control time between comparisons, defualt 0.3s (#265)
 - whisper-resize: Don't throw when trying to aggregate a null interval  (#266)
 - whisper-resize.py: Python3 fixes (#269)