### PR TITLE
Switch to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import os
 from glob import glob
-from distutils.core import setup
+from setuptools import setup
 
 
 def read(fname):
@@ -34,4 +34,5 @@ setup(
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
   ],
+  zip_safe=False
 )


### PR DESCRIPTION
removes warnings
UserWarning: Unknown distribution option: 'install_requires'
UserWarning: Unknown distribution option: 'long_description_content_type'

setuptools seems to be the recommended way now.