### PR TITLE
[1.1.x] set package long description | Switch to setuptools | adding appropriate 'type' to sleep variable | adding appropriate 'type' to sleep variable | Add testing for py38-dev and remove py34 | whisper-fil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ve
 .idea
 *.iml
 *.swp
+whisper.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 sudo: false
 python: 2.7
 
@@ -9,9 +10,6 @@ matrix:
     - python: 2.7
       env:
         - TOXENV=py27
-    - python: 3.4
-      env:
-        - TOXENV=py34
     - python: 3.5
       env:
         - TOXENV=py35
@@ -19,15 +17,16 @@ matrix:
       env:
         - TOXENV=py36
     - python: 3.7
-      dist: xenial
-      sudo: true
       env:
         - TOXENV=py37
+    - python: "3.8-dev"
+      env:
+       - TOXENV=py38
     - python: 3.7
-      dist: xenial
-      sudo: true
       env:
         - TOXENV=lint
+  allow_failures:
+    - python: "3.8-dev"
 
 install:
   - pip install tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include README.md
 exclude .* MANIFEST.in
 global-exclude __pycache__
 global-exclude *.py[co]

--- a/bin/rrd2whisper.py
+++ b/bin/rrd2whisper.py
@@ -1,4 +1,4 @@
-#!/home/rrawdon/git/whisper-env/bin/python3
+#!/usr/bin/env python
 
 import errno
 import os

--- a/bin/rrd2whisper.py
+++ b/bin/rrd2whisper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/home/rrawdon/git/whisper-env/bin/python3
 
 import errno
 import os
@@ -157,7 +157,7 @@ for datasource in datasources:
     values = [row[column_index] for row in rows]
     timestamps = list(range(*time_info))
     datapoints = zip(timestamps, values)
-    datapoints = filter(lambda p: p[1] is not None, datapoints)
+    datapoints = [datapoint for datapoint in datapoints if datapoint[1] is not None]
     print(' migrating %d datapoints from archive %d' % (len(datapoints), archiveNumber))
     archiveNumber -= 1
     whisper.update_many(path, datapoints)

--- a/bin/whisper-fill.py
+++ b/bin/whisper-fill.py
@@ -122,27 +122,27 @@ def fill_archives(src, dst, startFrom):
 
 
 def main():
-        option_parser = optparse.OptionParser(
-            usage='%prog [--lock] src dst',
-            description='copies data from src in dst, if missing')
-        option_parser.add_option(
-            '--lock', help='Lock whisper files',
-            default=False, action='store_true')
-        (options, args) = option_parser.parse_args()
+    option_parser = optparse.OptionParser(
+        usage='%prog [--lock] src dst',
+        description='copies data from src in dst, if missing')
+    option_parser.add_option(
+        '--lock', help='Lock whisper files',
+        default=False, action='store_true')
+    (options, args) = option_parser.parse_args()
 
-        if len(args) != 2:
-                option_parser.print_help()
-                sys.exit(1)
+    if len(args) != 2:
+        option_parser.print_help()
+        sys.exit(1)
 
-        if options.lock is True and whisper.CAN_LOCK:
-            whisper.LOCK = True
+    if options.lock is True and whisper.CAN_LOCK:
+        whisper.LOCK = True
 
-        src = args[0]
-        dst = args[1]
-        startFrom = time.time()
+    src = args[0]
+    dst = args[1]
+    startFrom = time.time()
 
-        fill_archives(src, dst, startFrom)
+    fill_archives(src, dst, startFrom)
 
 
 if __name__ == "__main__":
-        main()
+    main()

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -175,7 +175,7 @@ def cli_opts():
     parser.add_argument('--bindir', action='store', dest='bindir',
                         help="The root path to whisper-resize.py and whisper-info.py",
                         default='/opt/graphite/bin')
-    parser.add_argument('--sleep', action='store', type=int, dest='sleep',
+    parser.add_argument('--sleep', action='store', type=float, dest='sleep',
                         help="Sleep this amount of time in seconds between metric comparisons",
                         default=0.3)
     return parser.parse_args()

--- a/contrib/update-storage-times.py
+++ b/contrib/update-storage-times.py
@@ -175,7 +175,7 @@ def cli_opts():
     parser.add_argument('--bindir', action='store', dest='bindir',
                         help="The root path to whisper-resize.py and whisper-info.py",
                         default='/opt/graphite/bin')
-    parser.add_argument('--sleep', action='store', dest='sleep',
+    parser.add_argument('--sleep', action='store', type=int, dest='sleep',
                         help="Sleep this amount of time in seconds between metric comparisons",
                         default=0.3)
     return parser.parse_args()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python
 
+import os
 from glob import glob
 from distutils.core import setup
+
+
+def read(fname):
+    with open(os.path.join(os.path.dirname(__file__), fname)) as f:
+        return f.read()
 
 
 setup(
@@ -12,6 +18,8 @@ setup(
   author_email='chrismd@gmail.com',
   license='Apache Software License 2.0',
   description='Fixed size round-robin style database',
+  long_description=read('README.md'),
+  long_description_content_type='text/markdown',
   py_modules=['whisper'],
   scripts=glob('bin/*') + glob('contrib/*'),
   install_requires=['six'],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import os
 from glob import glob
-from distutils.core import setup
+from setuptools import setup
 
 
 def read(fname):
@@ -34,4 +34,5 @@ setup(
     'Programming Language :: Python :: Implementation :: CPython',
     'Programming Language :: Python :: Implementation :: PyPy',
   ],
+  zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
   py27,
-  py34,
   py35,
   py36,
   py37,
+  py38,
   pypy,
   pypy3,
   lint,


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - set package long description (#271)
 - Switch to setuptools (#272)
 - adding appropriate 'type' to sleep variable (#273)
 - adding appropriate 'type' to sleep variable (#273)
 - Add testing for py38-dev and remove py34 (#277)
 - whisper-fill: fix indentation (#277)
 - Altering rrd2whisper.py to use listcomp instead of filter() for py3 compatibility with len(), to fix #278 (#280)
 - Update rrd2whisper.py (#280)
 - Dump as raw values (#282)