### PR TITLE
Update info/fetch/dump description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,16 +73,18 @@ Options:
 
 whisper-dump.py
 ---------------
-Dump the metadata about a whisper file to stdout.
+Dump the whole whisper file content to stdout.
 
 ```
 Usage: whisper-dump.py path
 
 Options:
-  -h, --help  show this help message and exit
-  --pretty    Show human-readable timestamps instead of unix times
+  -h, --help            show this help message and exit
+  --pretty              Show human-readable timestamps instead of unix times
   -t TIME_FORMAT, --time-format=TIME_FORMAT
-              Time format to use with --pretty; see time.strftime()
+                        Time format to use with --pretty; see time.strftime()
+  -r, --raw             Dump value only in the same format for whisper-update
+                        (UTC timestamps)
 ```
 
 whisper-fetch.py
@@ -109,12 +111,14 @@ Options:
 
 whisper-info.py
 ---------------
+Dump the metadata about a whisper file to stdout.
 
 ```
-Usage: whisper-info.py path [field]
+Usage: whisper-info.py [options] path [field]
 
 Options:
   -h, --help  show this help message and exit
+  --json      Output results in JSON form
 ```
 
 whisper-merge.py


### PR DESCRIPTION
@piotr1212 - this PR is an attempt to improve the description of the whisper info/fetch/dump tools in the README, following up on the question in #303.

I think the description for whisper-dump was actually meant to be the description for whisper-info?

Overall I have to say that I think the description of whisper-fetch is still misleading:
> Fetch all the metrics stored in a whisper file to stdout.

I think there's only one metric per Whisper file? And it doesn't fetch all the metrics, it applies the behaviour described in https://graphite.readthedocs.io/en/latest/whisper.html#multi-archive-storage-and-retrieval-behavior to select one archive?

For dump it's not clear to me still how to get the content in machine-readable CSV format.

Overall, I'd like to suggest that the tool descriptions be moved to each tool, so that they are not just available in the README, but also locally when running `whisper-dump.py --help` etc.
This is easily achieved by putting it in the OptionParser description field: https://docs.python.org/3/library/optparse.html#optparse.OptionParser
Copy & pasting the `--help` output then to the README as is currently already done means the full and consistent description is also visible there online.
If you agree I'd be happy to apply this suggestion here in this PR or a follow-up PR.