### PR TITLE
[1.1.x] fix reisze whisper from low retention to high retention will lose some data (210d282d) | add test case and fix a litte bug (754a762d) | Fixing test for python 2.7 (0d8b6015) | Update info/fetch/dump description in README (64c450d0) 

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,10 @@
+version = 1
+
+test_patterns = ["*/test/**"]
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"

--- a/README.md
+++ b/README.md
@@ -72,16 +72,18 @@ Options:
 
 whisper-dump.py
 ---------------
-Dump the metadata about a whisper file to stdout.
+Dump the whole whisper file content to stdout.
 
 ```
 Usage: whisper-dump.py path
 
 Options:
-  -h, --help  show this help message and exit
-  --pretty    Show human-readable timestamps instead of unix times
+  -h, --help            show this help message and exit
+  --pretty              Show human-readable timestamps instead of unix times
   -t TIME_FORMAT, --time-format=TIME_FORMAT
-              Time format to use with --pretty; see time.strftime()
+                        Time format to use with --pretty; see time.strftime()
+  -r, --raw             Dump value only in the same format for whisper-update
+                        (UTC timestamps)
 ```
 
 whisper-fetch.py
@@ -108,12 +110,14 @@ Options:
 
 whisper-info.py
 ---------------
+Dump the metadata about a whisper file to stdout.
 
 ```
-Usage: whisper-info.py path [field]
+Usage: whisper-info.py [options] path [field]
 
 Options:
   -h, --help  show this help message and exit
+  --json      Output results in JSON form
 ```
 
 whisper-merge.py

--- a/bin/whisper-resize.py
+++ b/bin/whisper-resize.py
@@ -122,7 +122,7 @@ if options.aggregate:
       all_datapoints += new_datapoints[slice_end:]
     else:
       all_datapoints += new_datapoints
-    all_datapoints.reverse()
+  all_datapoints.reverse()
 
   oldtimestamps = list(map(lambda p: p[0], all_datapoints))
   oldvalues = list(map(lambda p: p[1], all_datapoints))

--- a/bin/whisper-resize.py
+++ b/bin/whisper-resize.py
@@ -107,20 +107,22 @@ if options.aggregate:
   # This is where data will be interpolated (best effort)
   print('Migrating data with aggregation...')
   all_datapoints = []
-  for archive in old_archives:
+  for archive in sorted(old_archives, key=lambda x: x['secondsPerPoint']):
     # Loading all datapoints into memory for fast querying
     timeinfo, values = archive['data']
     new_datapoints = list(zip(range(*timeinfo), values))
+    new_datapoints.reverse()
     if all_datapoints:
       last_timestamp = all_datapoints[-1][0]
       slice_end = 0
       for i, (timestamp, value) in enumerate(new_datapoints):
-        if timestamp > last_timestamp:
+        if timestamp < last_timestamp:
           slice_end = i
           break
-      all_datapoints += new_datapoints[i:]
+      all_datapoints += new_datapoints[slice_end:]
     else:
       all_datapoints += new_datapoints
+    all_datapoints.reverse()
 
   oldtimestamps = list(map(lambda p: p[0], all_datapoints))
   oldvalues = list(map(lambda p: p[1], all_datapoints))

--- a/test_whisper.py
+++ b/test_whisper.py
@@ -819,7 +819,7 @@ class TestWhisper(WhisperTestBase):
         whisper.create(self.filename, retention)
 
         # insert data
-        now_timestamp = int(datetime.now().timestamp())
+        now_timestamp = int((datetime.now() - datetime(1970, 1, 1)).total_seconds())
         now_timestamp -= now_timestamp % 60  # format timestamp
         points = [(now_timestamp - i * 60, i) for i in range(0, 60 * 24 * 2)]
         whisper.update_many(self.filename, points)

--- a/test_whisper.py
+++ b/test_whisper.py
@@ -239,7 +239,7 @@ class TestWhisper(WhisperTestBase):
         Behaviour when creating a whisper file on a full filesystem
         """
         m_open = mock_open()
-        # Get the mocked file object and override interresting attributes
+        # Get the mocked file object and override interesting attributes
         m_file = m_open.return_value
         m_file.name = self.filename
         method = getattr(m_file, exception_method)

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands =
   sh -c 'bin/whisper-update.py --help >/dev/null'
   sh -c 'contrib/whisper-auto-update.py --help >/dev/null'
   sh -c 'contrib/whisper-auto-resize.py --help >/dev/null'
-  coverage run --branch --include='whisper.py,test_whisper.py' test_whisper.py
+  coverage run --branch --include='whisper.py,test_whisper.py, bin/whisper-resize.py' test_whisper.py
   coverage xml
   coverage report
 deps =


### PR DESCRIPTION
Backports the following commits to 1.1.x:
 - fix reisze whisper from low retention to high retention will lose some data (210d282d)
 - add test case and fix a litte bug (754a762d)
 - Fixing test for python 2.7 (0d8b6015)
 - Update info/fetch/dump description in README (64c450d0)
 - docs: fix simple typo, interresting -> interesting (dc1572b8)