### PR TITLE
whisper-update takes values from stdin

### DIFF
--- a/bin/whisper-update.py
+++ b/bin/whisper-update.py
@@ -16,16 +16,22 @@ signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 now = int(time.time())
 
 option_parser = optparse.OptionParser(
-    usage='''%prog [options] path timestamp:value [timestamp:value]*''')
+  usage='''%prog [options] path [timestamp:value]*
+
+  If no values are passed as arguments, they are read one-per-line from stdin.''')
 
 (options, args) = option_parser.parse_args()
 
-if len(args) < 2:
+if not args:
   option_parser.print_help()
   sys.exit(1)
 
 path = args[0]
-datapoint_strings = args[1:]
+if len(args) >= 2:
+  datapoint_strings = args[1:]
+else:
+  # no argv values, so read from stdin
+  datapoint_strings = sys.stdin
 datapoint_strings = [point.replace('N:', '%d:' % now)
                      for point in datapoint_strings]
 datapoints = [tuple(point.split(':')) for point in datapoint_strings]


### PR DESCRIPTION
Nothing added to `test_whisper.py`, as it looks to cover the library but not the utilities.

Example usage:

    $ bin/whisper-create.py test.wsp 1s:7d
    Created: test.wsp (7257628 bytes)

    $ echo $'1624140281:44444\n1624140381:55555\n1624140581:66666' | bin/whisper-update.py test.wsp

    $ bin/whisper-dump.py test.wsp | grep 1624140
    0: 1624140281,      44444
    100: 1624140381,      55555
    300: 1624140581,      66666