### PR TITLE
Fix test_resize_with_aggregate on non-UTC systems

### DIFF
--- a/test_whisper.py
+++ b/test_whisper.py
@@ -819,7 +819,7 @@ class TestWhisper(WhisperTestBase):
         whisper.create(self.filename, retention)
 
         # insert data
-        now_timestamp = int((datetime.now() - datetime(1970, 1, 1)).total_seconds())
+        now_timestamp = int((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds())
         now_timestamp -= now_timestamp % 60  # format timestamp
         points = [(now_timestamp - i * 60, i) for i in range(0, 60 * 24 * 2)]
         whisper.update_many(self.filename, points)


### PR DESCRIPTION
Use datetime.utcnow() instead of .now() to calculate the UTC timestamp
without it being affected by the local timezone.  This fixes the test
failure on systems running non-UTC timezone.

Fixes #321