### PR TITLE
[1.1.x] Fix test_resize_with_aggregate on non-UTC systems (#322)

### DIFF
--- a/test_whisper.py
+++ b/test_whisper.py
@@ -819,7 +819,7 @@ class TestWhisper(WhisperTestBase):
         whisper.create(self.filename, retention)
 
         # insert data
-        now_timestamp = int((datetime.now() - datetime(1970, 1, 1)).total_seconds())
+        now_timestamp = int((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds())
         now_timestamp -= now_timestamp % 60  # format timestamp
         points = [(now_timestamp - i * 60, i) for i in range(0, 60 * 24 * 2)]
         whisper.update_many(self.filename, points)


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `1.1.x`:
 - [Fix test_resize_with_aggregate on non-UTC systems (#322)](https://github.com/graphite-project/whisper/pull/322)

<!--- Backport version: 7.4.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)