### PR TITLE
drop Python 2 support

### DIFF
--- a/bin/find-corrupt-whisper-files.py
+++ b/bin/find-corrupt-whisper-files.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 """Find and (optionally) delete corrupt Whisper data files"""
-from __future__ import absolute_import, print_function, unicode_literals
 
 import argparse
 import os

--- a/bin/whisper-dump.py
+++ b/bin/whisper-dump.py
@@ -5,7 +5,6 @@ import mmap
 import time
 import struct
 import signal
-import sys
 import optparse
 
 try:

--- a/bin/whisper-dump.py
+++ b/bin/whisper-dump.py
@@ -13,9 +13,6 @@ try:
 except ImportError:
   raise SystemExit('[ERROR] Please make sure whisper is installed properly')
 
-if sys.version_info >= (3, 0):
-  xrange = range
-
 # Ignore SIGPIPE
 signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
@@ -54,7 +51,7 @@ def read_header(map):
   archives = []
   archiveOffset = whisper.metadataSize
 
-  for i in xrange(archiveCount):
+  for i in range(archiveCount):
     try:
       (offset, secondsPerPoint, points) = struct.unpack(
         whisper.archiveInfoFormat,
@@ -107,7 +104,7 @@ def dump_archives(archives, options):
     if not options.raw:
       print('Archive %d data:' % i)
     offset = archive['offset']
-    for point in xrange(archive['points']):
+    for point in range(archive['points']):
       (timestamp, value) = struct.unpack(
         whisper.pointFormat,
         map[offset:offset + whisper.pointSize]

--- a/bin/whisper-fill.py
+++ b/bin/whisper-fill.py
@@ -27,11 +27,6 @@ import time
 import sys
 import optparse
 
-if sys.version_info >= (3, 0):
-    xrange = range
-else:
-    from future_builtins import filter, zip
-
 
 def itemgetter(*items):
     if HAS_OPERATOR:
@@ -80,7 +75,7 @@ def fill(src, dst, tstart, tstop):
         (start, end, archive_step) = timeInfo
         pointsToWrite = list(filter(
             lambda points: points[1] is not None,
-            zip(xrange(start, end, archive_step), values)))
+            zip(range(start, end, archive_step), values)))
         # order points by timestamp, newest first
         pointsToWrite.sort(key=lambda p: p[0], reverse=True)
         whisper.update_many(dst, pointsToWrite)

--- a/contrib/whisper-auto-resize.py
+++ b/contrib/whisper-auto-resize.py
@@ -7,7 +7,6 @@ from subprocess import call
 from optparse import OptionParser
 from shutil import which
 from os.path import basename
-from six.moves import input
 
 # On Debian systems whisper-resize.py is available as whisper-resize
 whisperResizeExecutable = which("whisper-resize.py")

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,7 @@ setup(
   long_description_content_type='text/markdown',
   py_modules=['whisper'],
   scripts=glob('bin/*') + glob('contrib/*'),
-  install_requires=['six'],
   classifiers=[
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',

--- a/test_whisper.py
+++ b/test_whisper.py
@@ -7,27 +7,11 @@ import math
 import random
 import struct
 import errno
+import unittest
 from datetime import datetime
+from io import StringIO
+from unittest.mock import patch, mock_open
 
-from six.moves import StringIO
-from six import assertRegex
-
-try:
-    from unittest.mock import patch, mock_open
-except ImportError:
-    from mock import patch, mock_open
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
-# For py3k in TestWhisper.test_merge
-try:
-    FileNotFoundError  # noqa
-except NameError:
-    class FileNotFoundError(Exception):
-        pass
 import whisper
 
 
@@ -725,7 +709,7 @@ class TestWhisper(WhisperTestBase):
 
         sys.stdout = old_stdout
 
-        assertRegex(self, out, r'(DEBUG :: (WRITE|READ) \d+ bytes #\d+\n)+')
+        self.assertRegex(out, r'(DEBUG :: (WRITE|READ) \d+ bytes #\d+\n)+')
 
     # TODO: This test method takes more time than virtually every
     #       single other test combined. Profile this code and potentially

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-  py27,
   py3,
   py39,
   py310,

--- a/whisper.py
+++ b/whisper.py
@@ -31,14 +31,10 @@ import os
 import platform
 import re
 import struct
-import sys
 import time
 
 izip = getattr(itertools, 'izip', zip)
 ifilter = getattr(itertools, 'ifilter', filter)
-
-if sys.version_info >= (3, 0):
-  xrange = range
 
 try:
   import fcntl
@@ -54,10 +50,7 @@ except ImportError:
   CAN_FALLOCATE = False
 
 try:
-  if sys.version_info >= (3, 0):
-    from os import posix_fadvise, POSIX_FADV_RANDOM
-  else:
-    from fadvise import posix_fadvise, POSIX_FADV_RANDOM
+  from os import posix_fadvise, POSIX_FADV_RANDOM
   CAN_FADVISE = True
 except ImportError:
   CAN_FADVISE = False
@@ -299,7 +292,7 @@ def __readHeader(fh):
 
   archives = []
 
-  for i in xrange(archiveCount):
+  for i in range(archiveCount):
     packedArchiveInfo = fh.read(archiveInfoSize)
     try:
       (offset, secondsPerPoint, points) = struct.unpack(archiveInfoFormat, packedArchiveInfo)
@@ -625,7 +618,7 @@ def __propagate(fh, header, timestamp, higher, lower):
   currentInterval = lowerIntervalStart
   step = higher['secondsPerPoint']
 
-  for i in xrange(0, len(unpackedSeries), 2):
+  for i in range(0, len(unpackedSeries), 2):
     pointTime = unpackedSeries[i]
     if pointTime == currentInterval:
       neighborValues[i // 2] = unpackedSeries[i + 1]
@@ -802,7 +795,7 @@ def __archive_update_many(fh, header, archive, points):
   previousInterval = None
   currentString = b""
   lenAlignedPoints = len(alignedPoints)
-  for i in xrange(0, lenAlignedPoints):
+  for i in range(0, lenAlignedPoints):
     # Take last point in run of points with duplicate intervals
     if i + 1 < lenAlignedPoints and alignedPoints[i][0] == alignedPoints[i + 1][0]:
       continue
@@ -1023,7 +1016,7 @@ archive on a read and request data older than the archive's retention
   valueList = [None] * points  # Pre-allocate entire list for speed
   currentInterval = fromInterval
 
-  for i in xrange(0, len(unpackedSeries), 2):
+  for i in range(0, len(unpackedSeries), 2):
     pointTime = unpackedSeries[i]
     if pointTime == currentInterval:
       pointValue = unpackedSeries[i + 1]
@@ -1088,7 +1081,7 @@ def file_merge(fh_from, fh_to, time_from=None, time_to=None, now=None):
     (start, end, archive_step) = timeInfo
     pointsToWrite = list(ifilter(
       lambda points: points[1] is not None,
-      izip(xrange(start, end, archive_step), values)))
+      izip(range(start, end, archive_step), values)))
     # skip if there are no points to write
     if len(pointsToWrite) == 0:
       continue
@@ -1136,7 +1129,7 @@ def file_diff(fh_from, fh_to, ignore_empty=False, until_time=None, now=None):
          min(fromTimeInfo[2], toTimeInfo[2]))
 
     points = map(lambda s: (s * archive_step + start, fromValues[s], toValues[s]),
-                 xrange(0, (end - start) // archive_step))
+                 range(0, (end - start) // archive_step))
     if ignore_empty:
       points = [p for p in points if p[1] is not None and p[2] is not None]
     else:


### PR DESCRIPTION
Hi,

I noticed that this packages still relies on `six`

Due to Debian freeze I'm putting my patching efforts on hold and providing upstream PR for the project that does not have one already.

https://wiki.debian.org/Python3-six-removal

Greetings