### PR TITLE
Handle missing libc during fallocate setup

### DIFF
--- a/test_whisper.py
+++ b/test_whisper.py
@@ -9,6 +9,11 @@ import struct
 import errno
 from datetime import datetime
 
+try:
+    from importlib import reload
+except ImportError:
+    pass
+
 from six.moves import StringIO
 from six import assertRegex
 
@@ -141,6 +146,21 @@ class TestWhisper(WhisperTestBase):
     """
     Testing functions for whisper.
     """
+    def test_fallocate_disabled_when_libc_missing(self):
+        try:
+            with patch('ctypes.util.find_library', return_value=None):
+                reload(whisper)
+                self.assertFalse(whisper.CAN_FALLOCATE)
+                self.assertIsNone(whisper.fallocate)
+        finally:
+            reload(whisper)
+
+        if whisper.CAN_FALLOCATE:
+            self.assertIsNotNone(whisper.fallocate)
+        else:
+            self.assertFalse(whisper.CAN_FALLOCATE)
+            self.assertIsNone(whisper.fallocate)
+
     def test_validate_archive_list(self):
         """
         blank archive config

--- a/test_whisper.py
+++ b/test_whisper.py
@@ -10,6 +10,12 @@ import errno
 from datetime import datetime
 
 try:
+    import ctypes
+    import ctypes.util
+except ImportError:
+    ctypes = None
+
+try:
     from importlib import reload
 except ImportError:
     pass
@@ -146,6 +152,7 @@ class TestWhisper(WhisperTestBase):
     """
     Testing functions for whisper.
     """
+    @unittest.skipIf(ctypes is None, 'ctypes is not available')
     def test_fallocate_disabled_when_libc_missing(self):
         try:
             with patch('ctypes.util.find_library', return_value=None):
@@ -160,6 +167,17 @@ class TestWhisper(WhisperTestBase):
         else:
             self.assertFalse(whisper.CAN_FALLOCATE)
             self.assertIsNone(whisper.fallocate)
+
+    @unittest.skipIf(ctypes is None, 'ctypes is not available')
+    def test_fallocate_disabled_when_libc_cannot_load(self):
+        try:
+            with patch('ctypes.util.find_library', return_value='libc'):
+                with patch('ctypes.CDLL', side_effect=OSError):
+                    reload(whisper)
+                    self.assertFalse(whisper.CAN_FALLOCATE)
+                    self.assertIsNone(whisper.fallocate)
+        finally:
+            reload(whisper)
 
     def test_validate_archive_list(self):
         """

--- a/test_whisper.py
+++ b/test_whisper.py
@@ -154,9 +154,7 @@ class TestWhisper(WhisperTestBase):
     """
     @unittest.skipIf(ctypes is None, 'ctypes is not available')
     def test_fallocate_disabled_when_libc_missing(self):
-        """
-        Disable fallocate when libc cannot be found.
-        """
+        """Disable fallocate when libc cannot be found."""
         try:
             with patch('ctypes.util.find_library', return_value=None):
                 reload(whisper)
@@ -173,15 +171,13 @@ class TestWhisper(WhisperTestBase):
 
     @unittest.skipIf(ctypes is None, 'ctypes is not available')
     def test_fallocate_disabled_when_libc_cannot_load(self):
-        """
-        Disable fallocate when libc cannot be loaded.
-        """
+        """Disable fallocate when libc cannot be loaded."""
         try:
-            with patch('ctypes.util.find_library', return_value='libc'):
-                with patch('ctypes.CDLL', side_effect=OSError):
-                    reload(whisper)
-                    self.assertFalse(whisper.CAN_FALLOCATE)
-                    self.assertIsNone(whisper.fallocate)
+            with patch('ctypes.util.find_library', return_value='libc'), \
+                    patch('ctypes.CDLL', side_effect=OSError):
+                reload(whisper)
+                self.assertFalse(whisper.CAN_FALLOCATE)
+                self.assertIsNone(whisper.fallocate)
         finally:
             reload(whisper)
 

--- a/test_whisper.py
+++ b/test_whisper.py
@@ -154,6 +154,9 @@ class TestWhisper(WhisperTestBase):
     """
     @unittest.skipIf(ctypes is None, 'ctypes is not available')
     def test_fallocate_disabled_when_libc_missing(self):
+        """
+        Disable fallocate when libc cannot be found.
+        """
         try:
             with patch('ctypes.util.find_library', return_value=None):
                 reload(whisper)
@@ -170,6 +173,9 @@ class TestWhisper(WhisperTestBase):
 
     @unittest.skipIf(ctypes is None, 'ctypes is not available')
     def test_fallocate_disabled_when_libc_cannot_load(self):
+        """
+        Disable fallocate when libc cannot be loaded.
+        """
         try:
             with patch('ctypes.util.find_library', return_value='libc'):
                 with patch('ctypes.CDLL', side_effect=OSError):

--- a/whisper.py
+++ b/whisper.py
@@ -66,33 +66,36 @@ fallocate = None
 
 if CAN_FALLOCATE:
   libc_name = ctypes.util.find_library('c')
-  libc = ctypes.CDLL(libc_name)
-  c_off64_t = ctypes.c_int64
-  c_off_t = ctypes.c_int
+  if libc_name is None:
+    CAN_FALLOCATE = False
+  else:
+    libc = ctypes.CDLL(libc_name)
+    c_off64_t = ctypes.c_int64
+    c_off_t = ctypes.c_int
 
-  if platform.uname()[0] == 'FreeBSD':
-    # offset type is 64-bit on FreeBSD 32-bit & 64-bit platforms to address files more than 2GB
-    c_off_t = ctypes.c_int64
+    if platform.uname()[0] == 'FreeBSD':
+      # offset type is 64-bit on FreeBSD 32-bit & 64-bit platforms to address files more than 2GB
+      c_off_t = ctypes.c_int64
 
-  try:
-    _fallocate = libc.posix_fallocate64
-    _fallocate.restype = ctypes.c_int
-    _fallocate.argtypes = [ctypes.c_int, c_off64_t, c_off64_t]
-  except AttributeError:
     try:
-      _fallocate = libc.posix_fallocate
+      _fallocate = libc.posix_fallocate64
       _fallocate.restype = ctypes.c_int
-      _fallocate.argtypes = [ctypes.c_int, c_off_t, c_off_t]
+      _fallocate.argtypes = [ctypes.c_int, c_off64_t, c_off64_t]
     except AttributeError:
-      CAN_FALLOCATE = False
+      try:
+        _fallocate = libc.posix_fallocate
+        _fallocate.restype = ctypes.c_int
+        _fallocate.argtypes = [ctypes.c_int, c_off_t, c_off_t]
+      except AttributeError:
+        CAN_FALLOCATE = False
 
-  if CAN_FALLOCATE:
-    def _py_fallocate(fd, offset, len_):
-      res = _fallocate(fd.fileno(), offset, len_)
-      if res != 0:
-        raise IOError(res, 'fallocate')
-    fallocate = _py_fallocate
-  del libc
+    if CAN_FALLOCATE:
+      def _py_fallocate(fd, offset, len_):
+        res = _fallocate(fd.fileno(), offset, len_)
+        if res != 0:
+          raise IOError(res, 'fallocate')
+      fallocate = _py_fallocate
+    del libc
   del libc_name
 
 LOCK = False

--- a/whisper.py
+++ b/whisper.py
@@ -64,43 +64,46 @@ except ImportError:
 
 fallocate = None
 
-if CAN_FALLOCATE:
+
+def _setup_fallocate():
   libc_name = ctypes.util.find_library('c')
   if libc_name is None:
-    CAN_FALLOCATE = False
-  else:
+    return None
+
+  try:
+    libc = ctypes.CDLL(libc_name)
+  except OSError:
+    return None
+
+  c_off64_t = ctypes.c_int64
+  c_off_t = ctypes.c_int
+
+  if platform.uname()[0] == 'FreeBSD':
+    # offset type is 64-bit on FreeBSD 32-bit & 64-bit platforms to address files more than 2GB
+    c_off_t = ctypes.c_int64
+
+  try:
+    _fallocate = libc.posix_fallocate64
+    _fallocate.restype = ctypes.c_int
+    _fallocate.argtypes = [ctypes.c_int, c_off64_t, c_off64_t]
+  except AttributeError:
     try:
-      libc = ctypes.CDLL(libc_name)
-    except OSError:
-      CAN_FALLOCATE = False
-    else:
-      c_off64_t = ctypes.c_int64
-      c_off_t = ctypes.c_int
+      _fallocate = libc.posix_fallocate
+      _fallocate.restype = ctypes.c_int
+      _fallocate.argtypes = [ctypes.c_int, c_off_t, c_off_t]
+    except AttributeError:
+      return None
 
-      if platform.uname()[0] == 'FreeBSD':
-        # offset type is 64-bit on FreeBSD 32-bit & 64-bit platforms to address files more than 2GB
-        c_off_t = ctypes.c_int64
+  def _py_fallocate(fd, offset, len_):
+    res = _fallocate(fd.fileno(), offset, len_)
+    if res != 0:
+      raise IOError(res, 'fallocate')
+  return _py_fallocate
 
-      try:
-        _fallocate = libc.posix_fallocate64
-        _fallocate.restype = ctypes.c_int
-        _fallocate.argtypes = [ctypes.c_int, c_off64_t, c_off64_t]
-      except AttributeError:
-        try:
-          _fallocate = libc.posix_fallocate
-          _fallocate.restype = ctypes.c_int
-          _fallocate.argtypes = [ctypes.c_int, c_off_t, c_off_t]
-        except AttributeError:
-          CAN_FALLOCATE = False
 
-      if CAN_FALLOCATE:
-        def _py_fallocate(fd, offset, len_):
-          res = _fallocate(fd.fileno(), offset, len_)
-          if res != 0:
-            raise IOError(res, 'fallocate')
-        fallocate = _py_fallocate
-      del libc
-  del libc_name
+if CAN_FALLOCATE:
+  fallocate = _setup_fallocate()
+  CAN_FALLOCATE = fallocate is not None
 
 LOCK = False
 CACHE_HEADERS = False

--- a/whisper.py
+++ b/whisper.py
@@ -69,33 +69,37 @@ if CAN_FALLOCATE:
   if libc_name is None:
     CAN_FALLOCATE = False
   else:
-    libc = ctypes.CDLL(libc_name)
-    c_off64_t = ctypes.c_int64
-    c_off_t = ctypes.c_int
-
-    if platform.uname()[0] == 'FreeBSD':
-      # offset type is 64-bit on FreeBSD 32-bit & 64-bit platforms to address files more than 2GB
-      c_off_t = ctypes.c_int64
-
     try:
-      _fallocate = libc.posix_fallocate64
-      _fallocate.restype = ctypes.c_int
-      _fallocate.argtypes = [ctypes.c_int, c_off64_t, c_off64_t]
-    except AttributeError:
-      try:
-        _fallocate = libc.posix_fallocate
-        _fallocate.restype = ctypes.c_int
-        _fallocate.argtypes = [ctypes.c_int, c_off_t, c_off_t]
-      except AttributeError:
-        CAN_FALLOCATE = False
+      libc = ctypes.CDLL(libc_name)
+    except OSError:
+      CAN_FALLOCATE = False
+    else:
+      c_off64_t = ctypes.c_int64
+      c_off_t = ctypes.c_int
 
-    if CAN_FALLOCATE:
-      def _py_fallocate(fd, offset, len_):
-        res = _fallocate(fd.fileno(), offset, len_)
-        if res != 0:
-          raise IOError(res, 'fallocate')
-      fallocate = _py_fallocate
-    del libc
+      if platform.uname()[0] == 'FreeBSD':
+        # offset type is 64-bit on FreeBSD 32-bit & 64-bit platforms to address files more than 2GB
+        c_off_t = ctypes.c_int64
+
+      try:
+        _fallocate = libc.posix_fallocate64
+        _fallocate.restype = ctypes.c_int
+        _fallocate.argtypes = [ctypes.c_int, c_off64_t, c_off64_t]
+      except AttributeError:
+        try:
+          _fallocate = libc.posix_fallocate
+          _fallocate.restype = ctypes.c_int
+          _fallocate.argtypes = [ctypes.c_int, c_off_t, c_off_t]
+        except AttributeError:
+          CAN_FALLOCATE = False
+
+      if CAN_FALLOCATE:
+        def _py_fallocate(fd, offset, len_):
+          res = _fallocate(fd.fileno(), offset, len_)
+          if res != 0:
+            raise IOError(res, 'fallocate')
+        fallocate = _py_fallocate
+      del libc
   del libc_name
 
 LOCK = False

--- a/whisper.py
+++ b/whisper.py
@@ -66,39 +66,39 @@ fallocate = None
 
 
 def _setup_fallocate():
-  libc_name = ctypes.util.find_library('c')
-  if libc_name is None:
-    return None
+    libc_name = ctypes.util.find_library('c')
+    if libc_name is None:
+        return None
 
-  try:
-    libc = ctypes.CDLL(libc_name)
-  except OSError:
-    return None
-
-  c_off64_t = ctypes.c_int64
-  c_off_t = ctypes.c_int
-
-  if platform.uname()[0] == 'FreeBSD':
-    # offset type is 64-bit on FreeBSD 32-bit & 64-bit platforms to address files more than 2GB
-    c_off_t = ctypes.c_int64
-
-  try:
-    _fallocate = libc.posix_fallocate64
-    _fallocate.restype = ctypes.c_int
-    _fallocate.argtypes = [ctypes.c_int, c_off64_t, c_off64_t]
-  except AttributeError:
     try:
-      _fallocate = libc.posix_fallocate
-      _fallocate.restype = ctypes.c_int
-      _fallocate.argtypes = [ctypes.c_int, c_off_t, c_off_t]
-    except AttributeError:
-      return None
+        libc = ctypes.CDLL(libc_name)
+    except OSError:
+        return None
 
-  def _py_fallocate(fd, offset, len_):
-    res = _fallocate(fd.fileno(), offset, len_)
-    if res != 0:
-      raise IOError(res, 'fallocate')
-  return _py_fallocate
+    c_off64_t = ctypes.c_int64
+    c_off_t = ctypes.c_int
+
+    if platform.uname()[0] == 'FreeBSD':
+        # offset type is 64-bit on FreeBSD 32-bit & 64-bit platforms to address files more than 2GB
+        c_off_t = ctypes.c_int64
+
+    try:
+        _fallocate = libc.posix_fallocate64
+        _fallocate.restype = ctypes.c_int
+        _fallocate.argtypes = [ctypes.c_int, c_off64_t, c_off64_t]
+    except AttributeError:
+        try:
+            _fallocate = libc.posix_fallocate
+            _fallocate.restype = ctypes.c_int
+            _fallocate.argtypes = [ctypes.c_int, c_off_t, c_off_t]
+        except AttributeError:
+            return None
+
+    def _py_fallocate(fd, offset, len_):
+        res = _fallocate(fd.fileno(), offset, len_)
+        if res != 0:
+            raise IOError(res, 'fallocate')
+    return _py_fallocate
 
 
 if CAN_FALLOCATE:

--- a/whisper.py
+++ b/whisper.py
@@ -66,6 +66,7 @@ fallocate = None
 
 
 def _setup_fallocate():
+    """Return a posix_fallocate wrapper when libc exposes one."""
     libc_name = ctypes.util.find_library('c')
     if libc_name is None:
         return None
@@ -79,7 +80,8 @@ def _setup_fallocate():
     c_off_t = ctypes.c_int
 
     if platform.uname()[0] == 'FreeBSD':
-        # offset type is 64-bit on FreeBSD 32-bit & 64-bit platforms to address files more than 2GB
+        # offset type is 64-bit on FreeBSD 32-bit & 64-bit platforms
+        # to address files more than 2GB.
         c_off_t = ctypes.c_int64
 
     try:


### PR DESCRIPTION
## Summary
- avoid calling `ctypes.CDLL(None)` when `ctypes.util.find_library('c')` cannot locate libc
- disable fallocate support in that case so `whisper` can still be imported and used without sparse preallocation
- add a regression test that reloads the module with libc lookup mocked as missing

## Why
On Windows, `ctypes` is available but `ctypes.util.find_library('c')` returns `None`. The module currently treats `ctypes` import success as enough to enable fallocate setup, then calls `ctypes.CDLL(None)`, which raises during import before callers or tests can use any other whisper functionality.

## Verification
- `python -m unittest test_whisper.TestWhisper.test_fallocate_disabled_when_libc_missing`
- `python -m unittest test_whisper.TestWhisper.test_validate_archive_list test_whisper.TestParseRetentionDef`
- `python -m py_compile whisper.py test_whisper.py`
- `python -m flake8 whisper.py test_whisper.py`
- `git diff --check`

I also ran `python test_whisper.py` on Windows. It now gets past the original import failure and runs tests, then hits existing Windows lock-path failures because `test_lock` enables `LOCK` where `fcntl` is unavailable.